### PR TITLE
WIP/spike: Mutable/unclobbered Drafts

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = app => {
       commits,
       config,
       lastRelease,
+      draftRelease,
       mergedPullRequests
     })
 

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -120,30 +120,53 @@ const templateNextVersion = (template, nextVersions) => {
     .replace('$NEXT_PATCH_VERSION', nextVersions.incrementedPatch || '')
 }
 
+const variableBlock = (variable, content) =>
+  `<!-- BEGIN ${variable} -->${content}<!-- END ${variable} -->`
+
+const replaceVariablesWithCommentBlocks = template =>
+  template.replace(/\$[A-Z_]+/g, variable => variableBlock(variable, '\n'))
+
+const generateBodyTemplate = (config, draftRelease) => {
+  if (draftRelease) {
+    return draftRelease.body
+  } else {
+    return replaceVariablesWithCommentBlocks(config.template)
+  }
+}
+
+const interpolateVariable = (body, variable, value) => {
+  let regexText = variableBlock(variable, '[\\s\\S]*').replace(/\$/g, '\\$')
+  let regex = new RegExp(regexText, 'mg')
+  return body.replace(regex, variableBlock(variable, `\n${value}\n`))
+}
+
 module.exports.generateReleaseInfo = ({
   commits,
   config,
   lastRelease,
+  draftRelease,
   mergedPullRequests
 }) => {
-  let body = config.template
+  let body = generateBodyTemplate(config, draftRelease)
+
   const [categoriesConfig, orderedCategories] = getCategoriesConfig({ config })
 
   if (!lastRelease) {
-    body = body.replace('$PREVIOUS_TAG', '')
+    body = interpolateVariable(body, '$PREVIOUS_TAG', '')
   } else {
-    body = body.replace('$PREVIOUS_TAG', lastRelease.tag_name)
+    body = interpolateVariable(body, '$PREVIOUS_TAG', lastRelease.tag_name)
   }
 
   if (mergedPullRequests.length === 0) {
-    body = body.replace('$CHANGES', config['no-changes-template'])
+    body = interpolateVariable(body, '$CHANGES', config['no-changes-template'])
   } else {
     const categorizedPullRequests = categorizePullRequests(
       mergedPullRequests,
       orderedCategories
     )
 
-    body = body.replace(
+    body = interpolateVariable(
+      body,
       '$CHANGES',
       orderedCategories
         .reduce((acc, category, index) => {
@@ -176,7 +199,8 @@ module.exports.generateReleaseInfo = ({
     )
   }
 
-  body = body.replace(
+  body = interpolateVariable(
+    body,
     '$CONTRIBUTORS',
     contributorsSentence({ commits, pullRequests: mergedPullRequests })
   )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,6 +79,12 @@ describe('release-drafter', () => {
         it('creates a release draft', async () => {
           getConfigMock('config-non-master-branch.yml')
 
+          const removeVariableComments = obj => {
+            return Object.assign({}, obj, {
+              body: obj.body.replace(/<!--.*?-->\n/g, '')
+            })
+          }
+
           nock('https://api.github.com')
             .get('/repos/toolmantim/release-drafter-test-project/releases')
             .query(true)
@@ -90,7 +96,7 @@ describe('release-drafter', () => {
             .post(
               '/repos/toolmantim/release-drafter-test-project/releases',
               body => {
-                expect(body).toMatchObject({
+                expect(removeVariableComments(body)).toMatchObject({
                   name: '',
                   tag_name: '',
                   body: `# What's Changed\n\n* No changes\n`,


### PR DESCRIPTION
A spike on how we might implement "mutable drafts",
i.e. drafts that are created/updated by Release
Drafter, but preserve any manual edits made to
the draft, i.e. checklists / extra release notes.

See here for more info:
https://github.com/toolmantim/release-drafter/issues/153#issuecomment-477674787