### PR TITLE
Add a `sort-by` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `categories`          | Optional | Categorize pull requests using labels. Refer to [Categorize Pull Requests](#categorize-pull-requests) to learn more about this option.                                                                            |
 | `exclude-lables`      | Optional | Exclude pull requests using labels. Refer to [Exclude Pull Requests](#exclude-pull-requests) to learn more about this option.                                                                                     |
 | `replacers`           | Optional | Search and replace content in the generated changelog body. Refer to [Replacers](#replacers) to learn more about this option.                                                                                     |
-| `sort-direction`      | Optional | Sort changelog by merged date in ascending or descending order. Can be one of: `ascending`, `descending`. Default: `descending`.                                                                                  |
+| `sort-by`             | Optional | Sort changelog by merged_at or title. Can be one of: `merged_at`, `title`. Default: `merged_at`.                                                                                                                  |
+| `sort-direction`      | Optional | Sort changelog in ascending or descending order. Can be one of: `ascending`, `descending`. Default: `descending`.                                                                                                 |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const { findReleases, generateReleaseInfo } = require('./lib/releases')
 const { findCommitsWithAssociatedPullRequests } = require('./lib/commits')
 const { validateReplacers } = require('./lib/template')
 const {
+  validateSortBy,
   validateSortDirection,
   sortPullRequests,
+  SORT_BY,
   SORT_DIRECTIONS
 } = require('./lib/sort-pull-requests')
 const log = require('./lib/log')
@@ -22,6 +24,7 @@ module.exports = app => {
       categories: [],
       'exclude-labels': [],
       replacers: [],
+      'sort-by': SORT_BY.mergedAt,
       'sort-direction': SORT_DIRECTIONS.descending
     }
     const config = Object.assign(
@@ -33,6 +36,7 @@ module.exports = app => {
       context,
       replacers: config.replacers
     })
+    config['sort-by'] = validateSortBy(config['sort-by'])
     config['sort-direction'] = validateSortDirection(config['sort-direction'])
 
     // GitHub Actions merge payloads slightly differ, in that their ref points
@@ -63,6 +67,7 @@ module.exports = app => {
 
     const sortedMergedPullRequests = sortPullRequests(
       mergedPullRequests,
+      config['sort-by'],
       config['sort-direction']
     )
 

--- a/lib/sort-pull-requests.js
+++ b/lib/sort-pull-requests.js
@@ -1,9 +1,19 @@
+const SORT_BY = {
+  mergedAt: 'merged_at',
+  title: 'title'
+}
+
 const SORT_DIRECTIONS = {
   ascending: 'ascending',
   descending: 'descending'
 }
 
+module.exports.SORT_BY = SORT_BY
 module.exports.SORT_DIRECTIONS = SORT_DIRECTIONS
+
+module.exports.validateSortBy = sortBy => {
+  return Object.values(SORT_BY).includes(sortBy) ? sortBy : SORT_BY.mergedAt
+}
 
 module.exports.validateSortDirection = sortDirection => {
   return Object.keys(SORT_DIRECTIONS).includes(sortDirection)
@@ -11,7 +21,9 @@ module.exports.validateSortDirection = sortDirection => {
     : SORT_DIRECTIONS.descending
 }
 
-module.exports.sortPullRequests = (pullRequests, sortDirection) => {
+module.exports.sortPullRequests = (pullRequests, sortBy, sortDirection) => {
+  const getSortFieldFn = sortBy === SORT_BY.title ? getTitle : getMergedAt
+
   const sortFn =
     sortDirection === SORT_DIRECTIONS.ascending
       ? dateSortAscending
@@ -19,7 +31,15 @@ module.exports.sortPullRequests = (pullRequests, sortDirection) => {
 
   return pullRequests
     .slice()
-    .sort((a, b) => sortFn(new Date(a.mergedAt), new Date(b.mergedAt)))
+    .sort((a, b) => sortFn(getSortFieldFn(a), getSortFieldFn(b)))
+}
+
+function getMergedAt(pullRequest) {
+  return new Date(pullRequest.mergedAt)
+}
+
+function getTitle(pullRequest) {
+  return pullRequest.title
 }
 
 function dateSortAscending(date1, date2) {

--- a/test/fixtures/config/config-with-sort-by-title.yml
+++ b/test/fixtures/config/config-with-sort-by-title.yml
@@ -1,0 +1,5 @@
+sort-by: 'title'
+template: |
+  # What's Changed
+
+  $CHANGES

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1097,6 +1097,69 @@ Previous tag: ''
     })
   })
 
+  describe('with sort-by config', () => {
+    it('sorts by title', async () => {
+      getConfigMock('config-with-sort-by-title.yml')
+
+      nock('https://api.github.com')
+        .post('/graphql', body =>
+          body.query.includes('query findCommitsWithAssociatedPullRequests')
+        )
+        .reply(200, require('./fixtures/graphql-commits-paginated-1.json'))
+        .post('/graphql', body =>
+          body.query.includes('query findCommitsWithAssociatedPullRequests')
+        )
+        .reply(200, require('./fixtures/graphql-commits-paginated-2.json'))
+
+      nock('https://api.github.com')
+        .get(
+          '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+        )
+        .reply(200, [])
+
+      nock('https://api.github.com')
+        .post(
+          '/repos/toolmantim/release-drafter-test-project/releases',
+          body => {
+            expect(body).toMatchObject({
+              body: `# What's Changed
+
+* 🤖 Add robots (#12) @toolmantim
+* 🙅🏼‍♂️ 🐄 (#5) @toolmantim
+* 👽 Integrate Alien technology (#8) @toolmantim
+* 👽 Added alien technology (#6) @toolmantim
+* 🐒 Add monkeys technology (#3) @toolmantim
+* 🐄 More cowbell (#4) @toolmantim
+* 🐄 Moar cowbell (#10) @toolmantim
+* 🎃 More pumpkins (#11) @toolmantim
+* ❤️ Add MOAR THINGS (#14) @toolmantim
+* Oh hai (#15) @toolmantim
+* Create new-feature.md (#1) @toolmantim
+* Adds a new Widgets API (#2) @toolmantim
+* Added great distance (#16) @toolmantim
+* Add ⛰ technology (#7) @toolmantim
+* Add all the tests (#13) @toolmantim
+* 1️⃣ Switch to a monorepo (#9) @toolmantim
+`,
+              draft: true,
+              tag_name: ''
+            })
+            return true
+          }
+        )
+        .reply(200)
+
+      const payload = require('./fixtures/push')
+
+      await probot.receive({
+        name: 'push',
+        payload
+      })
+
+      expect.assertions(1)
+    })
+  })
+
   describe('with sort-direction config', () => {
     it('sorts ascending', async () => {
       getConfigMock('config-with-sort-direction-ascending.yml')


### PR DESCRIPTION
Closes #323

This PR adds the `sort-by` option for users to be able to sort changelogs by `merged_at` or `title`.