### PR TITLE
Move GitHub App usage doc out of README to separate doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 
 ---
 
-[![NPM package](https://img.shields.io/npm/v/release-drafter-github-app.svg)](https://www.npmjs.com/package/release-drafter-github-app)
-
 ## Usage
-
-### GitHub Actions
 
 You can use the [Release Drafter GitHub Action](https://github.com/marketplace/actions/release-drafter) in a [GitHub Actions Workflow](https://help.github.com/en/articles/about-github-actions) by configuring a YAML-based workflow file, e.g. `.github/workflows/release-drafter.yml`, with the following:
 
@@ -33,9 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### GitHub App
-
-You can also install the [Release Drafter GitHub App](https://github.com/apps/release-drafter), choosing the repositories for which you want releases automatically created.
+If you're unable to use GitHub Actions, you can use the Release Drafter GitHub App. Please refer to the [Release Drafter GitHub App documentation](docs/github-app.md) for more information.
 
 ## Configuration
 
@@ -190,10 +184,6 @@ replacers:
 If your project doesn't follow [Semantic Versioning](https://semver.org) you can still use Release Drafter, but you may want to set the `version-template` option to customize how the `$NEXT_{PATCH,MINOR,MAJOR}_VERSION` environment variables are generated.
 
 For example, if your project doesn't use patch version numbers, you can set `version-template` to `$MAJOR.$MINOR`. If the current release is version 1.0, then `$NEXT_MINOR_VERSION` will be `1.1`.
-
-## GitHub Installation Permissions
-
-Release Drafter requires full write, because GitHub does not offer a limited scope for only writing releases. **Don't install Release Drafter to your entire GitHub account — only add the repositories you want to draft releases on.**
 
 ## Developing
 

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,11 @@
+# Release Drafter GitHub App [![NPM package](https://img.shields.io/npm/v/release-drafter-github-app.svg)](https://www.npmjs.com/package/release-drafter-github-app)
+
+If you're unable to use GitHub Actions, you can use the now deprecated [Release Drafter GitHub App](https://github.com/apps/release-drafter). Keep in mind that the Release Drafter GitHub App won't be receiving any new features (see: [#335](https://github.com/release-drafter/release-drafter/issues/335)).
+
+## Usage
+
+Install the [Release Drafter GitHub App](https://github.com/apps/release-drafter) and choose the repositories for which you want releases automatically created.
+
+## Installation permissions
+
+Release Drafter requires full write access, because GitHub does not offer a limited scope for only writing releases. **Don't install Release Drafter to your entire GitHub account — only add the repositories you want to draft releases on.**


### PR DESCRIPTION
Move the usage doc for the Release Drafter GitHub App to a separate doc to make it less prominent and stimulate the use of the GitHub Action.

Related to https://github.com/release-drafter/release-drafter/issues/335