### PR TITLE
Add "prerelease" config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `replacers`           | Optional | Search and replace content in the generated changelog body. Refer to [Replacers](#replacers) to learn more about this option.                                                                                     |
 | `sort-by`             | Optional | Sort changelog by merged_at or title. Can be one of: `merged_at`, `title`. Default: `merged_at`.                                                                                                                  |
 | `sort-direction`      | Optional | Sort changelog in ascending or descending order. Can be one of: `ascending`, `descending`. Default: `descending`.                                                                                                 |
+| `prerelease`          | Optional | Mark the draft release as pre-release. Default `false`.                                                                                                                                                           |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ module.exports = app => {
           name: releaseInfo.name,
           tag_name: releaseInfo.tag,
           body: releaseInfo.body,
-          draft: true
+          draft: true,
+          prerelease: config.prerelease
         })
       )
       const {

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,8 @@ const DEFAULT_CONFIG = Object.freeze({
   categories: [],
   'exclude-labels': [],
   replacers: [],
-  'sort-direction': SORT_DIRECTIONS.descending
+  'sort-direction': SORT_DIRECTIONS.descending,
+  prerelease: false
 })
 
 module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG


### PR DESCRIPTION
Fixes: https://github.com/release-drafter/release-drafter/issues/332

Allows marking the draft as pre-release when it is created, throught the `prerelease` config option.