### PR TITLE
Allow specifying the config name through an input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       - uses: release-drafter/release-drafter@v5
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-          config-name: my-config.yml
+          # config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = app => {
       app,
       context,
       getConfig: require('probot-config'),
-      configName: process.env['CONFIG_NAME']
+      configName: core.getInput('config-name')
     })
 
     if (config === null) return

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = app => {
     const config = await getConfig({
       app,
       context,
-      getConfig: require('probot-config')
+      getConfig: require('probot-config'),
+      configName: process.env['CONFIG_NAME']
     })
 
     if (config === null) return

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,15 +2,20 @@ const { validateSchema } = require('./schema')
 const { DEFAULT_CONFIG } = require('./default-config')
 const log = require('./log')
 
-const CONFIG_NAME = 'release-drafter.yml'
+const DEFAULT_CONFIG_NAME = 'release-drafter.yml'
 
 module.exports.getConfig = async function getConfig({
   app,
   context,
+  configName,
   getConfig: fetchConfig
 }) {
   try {
-    const repoConfig = await fetchConfig(context, CONFIG_NAME, DEFAULT_CONFIG)
+    const repoConfig = await fetchConfig(
+      context,
+      configName || DEFAULT_CONFIG_NAME,
+      DEFAULT_CONFIG
+    )
 
     const config = validateSchema(app, context, repoConfig)
 

--- a/test/fixtures/config/config-name-input.yml
+++ b/test/fixtures/config/config-name-input.yml
@@ -1,0 +1,2 @@
+template: |
+  # There's new stuff!

--- a/test/helpers/config-mock.js
+++ b/test/helpers/config-mock.js
@@ -2,40 +2,39 @@ const fs = require('fs')
 const nock = require('nock')
 const { encodeContent } = require('../../lib/base64')
 
-function configFixture(fileName = 'config.yml') {
+function configFixture(
+  fileName = 'config.yml',
+  repoFileName = 'release-drafter.yml'
+) {
   return {
     type: 'file',
     encoding: 'base64',
     size: 5362,
-    name: 'release-drafter.yml',
-    path: '.github/release-drafter.yml',
+    name: repoFileName,
+    path: `.github/${repoFileName}`,
     content: encodeContent(
       fs.readFileSync(`${__dirname}/../fixtures/config/${fileName}`)
     ),
     sha: '3d21ec53a331a6f037a91c368710b99387d012c1',
-    url:
-      'https://api.github.com/repos/octokit/octokit.rb/contents/.github/release-drafter.yml',
-    git_url:
-      'https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1',
-    html_url:
-      'https://github.com/octokit/octokit.rb/blob/master/.github/release-drafter.yml',
-    download_url:
-      'https://raw.githubusercontent.com/octokit/octokit.rb/master/.github/release-drafter.yml',
+    url: `https://api.github.com/repos/octokit/octokit.rb/contents/.github/${repoFileName}`,
+    git_url: `https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1`,
+    html_url: `https://github.com/octokit/octokit.rb/blob/master/.github/${repoFileName}`,
+    download_url: `https://raw.githubusercontent.com/octokit/octokit.rb/master/.github/${repoFileName}`,
     _links: {
-      git:
-        'https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1',
-      self:
-        'https://api.github.com/repos/octokit/octokit.rb/contents/.github/release-drafter.yml',
-      html:
-        'https://github.com/octokit/octokit.rb/blob/master/.github/release-drafter.yml'
+      git: `https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1`,
+      self: `https://api.github.com/repos/octokit/octokit.rb/contents/.github/${repoFileName}`,
+      html: `https://github.com/octokit/octokit.rb/blob/master/.github/${repoFileName}`
     }
   }
 }
 
-module.exports = function getConfigMock(fileName) {
+module.exports = function getConfigMock(
+  fileName,
+  repoFileName = 'release-drafter.yml'
+) {
   return nock('https://api.github.com')
     .get(
-      '/repos/toolmantim/release-drafter-test-project/contents/.github/release-drafter.yml'
+      `/repos/toolmantim/release-drafter-test-project/contents/.github/${repoFileName}`
     )
-    .reply(200, configFixture(fileName))
+    .reply(200, configFixture(fileName, repoFileName))
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1286,39 +1286,10 @@ Previous tag: ''
       process.env['INPUT_CONFIG-NAME'] = 'config-name-input.yml'
 
       // Mock config request for file 'config-name-input.yml'
-      const getConfigScope = nock('https://api.github.com')
-        .get(
-          '/repos/toolmantim/release-drafter-test-project/contents/.github/config-name-input.yml'
-        )
-        .reply(200, {
-          type: 'file',
-          encoding: 'base64',
-          size: 5362,
-          name: 'config-name-input.yml',
-          path: '.github/config-name-input.yml',
-          content: encodeContent(
-            fs.readFileSync(
-              `${__dirname}/fixtures/config/config-name-input.yml`
-            )
-          ),
-          sha: '3d21ec53a331a6f037a91c368710b99387d012c1',
-          url:
-            'https://api.github.com/repos/octokit/octokit.rb/contents/.github/config-name-input.yml',
-          git_url:
-            'https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1',
-          html_url:
-            'https://github.com/octokit/octokit.rb/blob/master/.github/config-name-input.yml',
-          download_url:
-            'https://raw.githubusercontent.com/octokit/octokit.rb/master/.github/config-name-input.yml',
-          _links: {
-            git:
-              'https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1',
-            self:
-              'https://api.github.com/repos/octokit/octokit.rb/contents/.github/config-name-input.yml',
-            html:
-              'https://github.com/octokit/octokit.rb/blob/master/.github/config-name-input.yml'
-          }
-        })
+      const getConfigScope = getConfigMock(
+        'config-name-input.yml',
+        'config-name-input.yml'
+      )
 
       nock('https://api.github.com')
         .post('/graphql', body =>


### PR DESCRIPTION
This is useful if you want to create different drafts, depending on the triggered workflow.
You may want to create a pre-release draft in the development branch (targeting this branch) and have a `-alpha` suffix in the tag-template and, separately, create a release draft in the master branch (targeting it), without the suffix in the tag-template and maybe other different options.
So, in the workflow we can pass a different config name as an env variable when using release-drafter.