### PR TITLE
Override calculated version, tag and name with input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@ jobs:
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           # config-name: my-config.yml
+          # (Optional) override the calculated version
+          # version: '2.1.1'
+          # (Optional) override the resulting tag
+          # version: 'v2.1.1-alpha'
+          # (Optional) override the resulting name
+          # version: 'v2.1.1-alpha (Code Name: Foxtrot Unicorn)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+**Note:** If provided, the `version`, `tag` and `name` input options will be used (in this order) to extract a version number instead of calculating one.
 
 If you're unable to use GitHub Actions, you can use the Release Drafter GitHub App. Please refer to the [Release Drafter GitHub App documentation](docs/github-app.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-**Note:** If provided, the `version`, `tag` and `name` input options will be used (in this order) to extract a version number instead of calculating one.
-
 If you're unable to use GitHub Actions, you can use the Release Drafter GitHub App. Please refer to the [Release Drafter GitHub App documentation](docs/github-app.md) for more information.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
           # (Optional) override the resulting tag
           # tag: 'v2.1.1-alpha'
           # (Optional) override the resulting name
-          # version: 'v2.1.1-alpha (Code Name: Foxtrot Unicorn)'
+          # name: 'v2.1.1-alpha (Code Name: Foxtrot Unicorn)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ jobs:
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           # config-name: my-config.yml
-          # (Optional) override the calculated version
-          # version: '2.1.1'
-          # (Optional) override the resulting tag
-          # tag: 'v2.1.1-alpha'
-          # (Optional) override the resulting name
-          # name: 'v2.1.1-alpha (Code Name: Foxtrot Unicorn)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -126,8 +120,6 @@ You can use any of the following variables in your `template`, `name-template` a
 | `$NEXT_PATCH_VERSION` | The next patch version number. For example, if the last tag or release was `v1.2.3`, the value would be `v1.2.4`. This is the most commonly used value. |
 | `$NEXT_MINOR_VERSION` | The next minor version number. For example, if the last tag or release was `v1.2.3`, the value would be `v1.3.0`.                                       |
 | `$NEXT_MAJOR_VERSION` | The next major version number. For example, if the last tag or release was `v1.2.3`, the value would be `v2.0.0`.                                       |
-| `$INPUT_VERSION`      | Manually set version, extracted from the `version`, `tag` or `name` override options (in this order).                                                   |
-| `$RESOLVED_VERSION`   | The `$INPUT_VERSION` if available, or `$NEXT_PATCH_VERSION` otherwise.                                                                                  |
 
 ## Version Template Variables
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ You can use any of the following variables in your `template`, `name-template` a
 | `$NEXT_PATCH_VERSION` | The next patch version number. For example, if the last tag or release was `v1.2.3`, the value would be `v1.2.4`. This is the most commonly used value. |
 | `$NEXT_MINOR_VERSION` | The next minor version number. For example, if the last tag or release was `v1.2.3`, the value would be `v1.3.0`.                                       |
 | `$NEXT_MAJOR_VERSION` | The next major version number. For example, if the last tag or release was `v1.2.3`, the value would be `v2.0.0`.                                       |
+| `$INPUT_VERSION`      | Manually set version, extracted from the `version`, `tag` or `name` override options (in this order).                                                   |
+| `$RESOLVED_VERSION`   | The `$INPUT_VERSION` if available, or `$NEXT_PATCH_VERSION` otherwise.                                                                                  |
 
 ## Version Template Variables
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
           # (Optional) override the calculated version
           # version: '2.1.1'
           # (Optional) override the resulting tag
-          # version: 'v2.1.1-alpha'
+          # tag: 'v2.1.1-alpha'
           # (Optional) override the resulting name
           # version: 'v2.1.1-alpha (Code Name: Foxtrot Unicorn)'
         env:

--- a/index.js
+++ b/index.js
@@ -48,7 +48,10 @@ module.exports = app => {
       commits,
       config,
       lastRelease,
-      mergedPullRequests: sortedMergedPullRequests
+      mergedPullRequests: sortedMergedPullRequests,
+      version: core.getInput('version') || undefined,
+      tag: core.getInput('tag') || undefined,
+      name: core.getInput('name') || undefined
     })
 
     let createOrUpdateReleaseResponse

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -190,13 +190,13 @@ module.exports.generateReleaseInfo = ({
     config.replacers
   )
 
-  // Use the first override parameter to identify
-  // a version, from the most accurate to the least
-  const versionish = version || tag || name
-
-  const versionInfo = versionish
-    ? getVersionInfo(versionish, config['version-template'], false)
-    : getVersionInfo(lastRelease, config['version-template'])
+  const versionInfo = getVersionInfo(
+    lastRelease,
+    config['version-template'],
+    // Use the first override parameter to identify
+    // a version, from the most accurate to the least
+    version || tag || name
+  )
 
   if (versionInfo) {
     body = template(body, versionInfo)

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -203,11 +203,13 @@ module.exports.generateReleaseInfo = ({
   }
 
   if (tag === undefined) {
-    tag = template(config['tag-template'] || '', versionInfo)
+    tag = versionInfo ? template(config['tag-template'] || '', versionInfo) : ''
   }
 
   if (name === undefined) {
-    name = template(config['name-template'] || '', versionInfo)
+    name = versionInfo
+      ? template(config['name-template'] || '', versionInfo)
+      : ''
   }
 
   return {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -170,7 +170,10 @@ module.exports.generateReleaseInfo = ({
   commits,
   config,
   lastRelease,
-  mergedPullRequests
+  mergedPullRequests,
+  version = undefined,
+  tag = undefined,
+  name = undefined
 }) => {
   let body = config.template
 
@@ -187,28 +190,29 @@ module.exports.generateReleaseInfo = ({
     config.replacers
   )
 
-  if (lastRelease) {
-    let name = config['name-template']
-    let tag = config['tag-template']
+  // Use the first override parameter to identify
+  // a version, from the most accurate to the least
+  const versionish = version || tag || name
 
-    const versionInfo = getVersionInfo(lastRelease, config['version-template'])
-    if (versionInfo) {
-      body = template(body, versionInfo)
-      name = template(name, versionInfo)
-      tag = template(tag, versionInfo)
-    }
+  const versionInfo = versionish
+    ? getVersionInfo(versionish, config['version-template'], false)
+    : getVersionInfo(lastRelease, config['version-template'])
 
-    return {
-      name,
-      tag,
-      body
-    }
-  } else {
-    // There is no previous version, so we cannot template the name/tag
-    return {
-      name: '',
-      tag: '',
-      body
-    }
+  if (versionInfo) {
+    body = template(body, versionInfo)
+  }
+
+  if (tag === undefined) {
+    tag = template(config['tag-template'] || '', versionInfo)
+  }
+
+  if (name === undefined) {
+    name = template(config['name-template'] || '', versionInfo)
+  }
+
+  return {
+    name,
+    tag,
+    body
   }
 }

--- a/lib/template.js
+++ b/lib/template.js
@@ -10,7 +10,7 @@ const regexEscape = require('escape-string-regexp')
 const template = (string, obj, customReplacers) => {
   let str = string.replace(/(\$[A-Z_]+)/g, (_, k) => {
     let result
-    if (obj[k] === undefined) {
+    if (obj[k] === undefined || obj[k] === null) {
       result = k
     } else if (typeof obj[k] === 'object') {
       result = template(obj[k].template, obj[k])

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -18,12 +18,20 @@ const splitSemVer = (input, versionKey = 'version') => {
   }
 }
 
-const getTemplatableVersion = input => ({
-  $NEXT_MAJOR_VERSION: splitSemVer({ ...input, inc: 'major' }),
-  $NEXT_MINOR_VERSION: splitSemVer({ ...input, inc: 'minor' }),
-  $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' }),
-  $INPUT_VERSION: splitSemVer(input, 'inputVersion')
-})
+const getTemplatableVersion = input => {
+  const templatableVersion = {
+    $NEXT_MAJOR_VERSION: splitSemVer({ ...input, inc: 'major' }),
+    $NEXT_MINOR_VERSION: splitSemVer({ ...input, inc: 'minor' }),
+    $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' }),
+    $INPUT_VERSION: splitSemVer(input, 'inputVersion'),
+    $RESOLVED_VERSION: null
+  }
+
+  templatableVersion.$RESOLVED_VERSION =
+    templatableVersion.$INPUT_VERSION || templatableVersion.$NEXT_PATCH_VERSION
+
+  return templatableVersion
+}
 
 const coerceVersion = input => {
   if (!input) {

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,7 +1,10 @@
 const semver = require('semver')
 
 const splitSemVer = input => {
-  const version = semver.inc(input.lastVersion, input.inc, true)
+  const version =
+    !input.increment && input.inc === 'patch'
+      ? semver.parse(input.version)
+      : semver.inc(input.version, input.inc, true)
 
   return {
     ...input,
@@ -12,24 +15,27 @@ const splitSemVer = input => {
   }
 }
 
-const lastVersionSemVerIncremented = input => ({
+const getTemplatableVersion = input => ({
   $NEXT_MAJOR_VERSION: splitSemVer({ ...input, inc: 'major' }),
   $NEXT_MINOR_VERSION: splitSemVer({ ...input, inc: 'minor' }),
   $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' })
 })
 
-module.exports.getVersionInfo = (lastRelease, template) => {
-  const lastVersion =
-    semver.coerce(lastRelease.tag_name) || semver.coerce(lastRelease.name)
+module.exports.getVersionInfo = (release, template, increment = true) => {
+  const version =
+    typeof release === 'object'
+      ? semver.coerce(release.tag_name) || semver.coerce(release.name)
+      : semver.coerce(release)
 
-  if (!lastVersion) {
+  if (!version) {
     return undefined
   }
 
   return {
-    ...lastVersionSemVerIncremented({
-      lastVersion,
-      template
+    ...getTemplatableVersion({
+      version,
+      template,
+      increment
     })
   }
 }

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,10 +1,13 @@
 const semver = require('semver')
 
-const splitSemVer = input => {
-  const version =
-    !input.increment && input.inc === 'patch'
-      ? semver.parse(input.version)
-      : semver.inc(input.version, input.inc, true)
+const splitSemVer = (input, versionKey = 'version') => {
+  if (!input[versionKey]) {
+    return null
+  }
+
+  const version = input.inc
+    ? semver.inc(input[versionKey], input.inc, true)
+    : semver.parse(input[versionKey])
 
   return {
     ...input,
@@ -18,16 +21,25 @@ const splitSemVer = input => {
 const getTemplatableVersion = input => ({
   $NEXT_MAJOR_VERSION: splitSemVer({ ...input, inc: 'major' }),
   $NEXT_MINOR_VERSION: splitSemVer({ ...input, inc: 'minor' }),
-  $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' })
+  $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' }),
+  $INPUT_VERSION: splitSemVer(input, 'inputVersion')
 })
 
-module.exports.getVersionInfo = (release, template, increment = true) => {
-  const version =
-    typeof release === 'object'
-      ? semver.coerce(release.tag_name) || semver.coerce(release.name)
-      : semver.coerce(release)
+const coerceVersion = input => {
+  if (!input) {
+    return null
+  }
 
-  if (!version) {
+  return typeof input === 'object'
+    ? semver.coerce(input.tag_name) || semver.coerce(input.name)
+    : semver.coerce(input)
+}
+
+module.exports.getVersionInfo = (release, template, inputVersion = null) => {
+  const version = coerceVersion(release)
+  inputVersion = coerceVersion(inputVersion)
+
+  if (!version && !inputVersion) {
     return undefined
   }
 
@@ -35,7 +47,7 @@ module.exports.getVersionInfo = (release, template, increment = true) => {
     ...getTemplatableVersion({
       version,
       template,
-      increment
+      inputVersion
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jest": "24.9.0",
     "joi-to-json-schema": "^5.1.0",
     "lint-staged": "9.5.0",
+    "mocked-env": "^1.3.2",
     "nock": "11.7.2",
     "nock-knock": "2.0.0",
     "node-fetch": "2.6.0",

--- a/test/fixtures/config/config-with-input-version-template.yml
+++ b/test/fixtures/config/config-with-input-version-template.yml
@@ -1,0 +1,4 @@
+template: Placeholder with example. Automatically calculated values based on previous releases are next major=$NEXT_MAJOR_VERSION, minor=$NEXT_MINOR_VERSION, patch=$NEXT_PATCH_VERSION. Manual input version is $INPUT_VERSION.
+name-template: 'v$INPUT_VERSION (Code name: Placeholder)'
+tag-template: v$INPUT_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/test/fixtures/config/config-with-resolved-version-template.yml
+++ b/test/fixtures/config/config-with-resolved-version-template.yml
@@ -1,0 +1,26 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+branches:
+  - master
+categories:
+  - title: '🚀 Features'
+    label: 'feature'
+  - title: '🐛 Bug fixes'
+    label: 'bug'
+  - title: '📄 Documentation'
+    label: 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'maintenance'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  ## Previous release
+
+  $PREVIOUS_TAG

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ const getConfigMock = require('./helpers/config-mock')
 const releaseDrafter = require('../index')
 const fs = require('fs')
 const { encodeContent } = require('../lib/base64')
+const mockedEnv = require('mocked-env')
 
 nock.disableNetConnect()
 
@@ -27,6 +28,7 @@ Pc6zWtW2XuNIGHw9pDj7v1yDolm7feBXLg8/u9APwHDy
 describe('release-drafter', () => {
   let probot
   let logger
+  let restoreEnv
 
   beforeEach(() => {
     logger = jest.fn()
@@ -42,6 +44,8 @@ describe('release-drafter', () => {
       .post('/app/installations/179208/access_tokens')
       .reply(200, { token: 'test' })
 
+    let mockEnv = {}
+
     // We have to delete all the GITHUB_* envs before every test, because if
     // we're running the tests themselves inside a GitHub Actions container
     // they'll mess with the tests, and also because we set some of them in
@@ -49,12 +53,18 @@ describe('release-drafter', () => {
     Object.keys(process.env)
       .filter(key => key.match(/^GITHUB_/))
       .forEach(key => {
-        delete process.env[key]
+        mockEnv[key] = undefined
       })
+
+    restoreEnv = mockedEnv(mockEnv)
   })
 
   afterAll(nock.restore)
-  afterEach(nock.cleanAll)
+
+  afterEach(() => {
+    nock.cleanAll()
+    restoreEnv()
+  })
 
   describe('push', () => {
     describe('without a config', () => {
@@ -1325,6 +1335,131 @@ Previous tag: ''
       expect(getConfigScope.isDone()).toBe(true)
 
       expect.assertions(2)
+    })
+  })
+
+  describe('input version, tag and name overrides', () => {
+    // Method with all the test's logic, to prevent duplication
+    const overridesTest = async (overrides, expectedBody) => {
+      let mockEnv = {}
+
+      /*
+        Mock
+        with:
+          # any combination (or none) of these input options (examples):
+          version: '2.1.1'
+          tag: 'v2.1.1-alpha'
+          name: 'v2.1.1-alpha (Code name: Example)'
+      */
+      if (overrides) {
+        if (overrides.version) {
+          mockEnv['INPUT_VERSION'] = overrides.version
+        }
+
+        if (overrides.tag) {
+          mockEnv['INPUT_TAG'] = overrides.tag
+        }
+
+        if (overrides.name) {
+          mockEnv['INPUT_NAME'] = overrides.name
+        }
+      }
+
+      let restoreEnv = mockedEnv(mockEnv)
+
+      getConfigMock('config-with-major-minor-patch-version-template.yml')
+
+      nock('https://api.github.com')
+        .get('/repos/toolmantim/release-drafter-test-project/releases')
+        .query(true)
+        .reply(200, [require('./fixtures/release')])
+
+      nock('https://api.github.com')
+        .post('/graphql', body =>
+          body.query.includes('query findCommitsWithAssociatedPullRequests')
+        )
+        .reply(
+          200,
+          require('./fixtures/__generated__/graphql-commits-merge-commit.json')
+        )
+
+      nock('https://api.github.com')
+        .post(
+          '/repos/toolmantim/release-drafter-test-project/releases',
+          body => {
+            expect(body).toMatchObject(expectedBody)
+            return true
+          }
+        )
+        .reply(200)
+
+      await probot.receive({
+        name: 'push',
+        payload: require('./fixtures/push')
+      })
+
+      expect.assertions(1)
+
+      restoreEnv()
+    }
+
+    describe('with just the version', () => {
+      it('forces the version on templates', async () => {
+        return overridesTest(
+          { version: '2.1.1' },
+          {
+            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            draft: true,
+            name: 'v2.1.1 (Code name: Placeholder)',
+            tag_name: 'v2.1.1'
+          }
+        )
+      })
+    })
+
+    describe('with just the tag', () => {
+      it('gets the version from the tag and forces using the tag', async () => {
+        return overridesTest(
+          { tag: 'v2.1.1-alpha' },
+          {
+            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            draft: true,
+            name: 'v2.1.1 (Code name: Placeholder)',
+            tag_name: 'v2.1.1-alpha'
+          }
+        )
+      })
+    })
+
+    describe('with just the name', () => {
+      it('gets the version from the name and forces using the name', async () => {
+        return overridesTest(
+          { name: 'v2.1.1-alpha (Code name: Foxtrot Unicorn)' },
+          {
+            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            draft: true,
+            name: 'v2.1.1-alpha (Code name: Foxtrot Unicorn)',
+            tag_name: 'v2.1.1'
+          }
+        )
+      })
+    })
+
+    describe('with tag and name', () => {
+      it('gets the version from the tag and forces using the tag and name', async () => {
+        return overridesTest(
+          {
+            tag: 'v2.1.1-foxtrot-unicorn-alpha',
+            name: 'Foxtrot Unicorn'
+          },
+          {
+            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            draft: true,
+            name: 'Foxtrot Unicorn',
+            tag_name: 'v2.1.1-foxtrot-unicorn-alpha'
+          }
+        )
+      })
     })
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1293,7 +1293,9 @@ Previous tag: ''
         with:
           config-name: 'config-name-input.yml'
       */
-      process.env['INPUT_CONFIG-NAME'] = 'config-name-input.yml'
+      let restoreEnv = mockedEnv({
+        'INPUT_CONFIG-NAME': 'config-name-input.yml'
+      })
 
       // Mock config request for file 'config-name-input.yml'
       const getConfigScope = getConfigMock(
@@ -1335,6 +1337,8 @@ Previous tag: ''
       expect(getConfigScope.isDone()).toBe(true)
 
       expect.assertions(2)
+
+      restoreEnv()
     })
   })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1367,7 +1367,7 @@ Previous tag: ''
 
       let restoreEnv = mockedEnv(mockEnv)
 
-      getConfigMock('config-with-major-minor-patch-version-template.yml')
+      getConfigMock('config-with-input-version-template.yml')
 
       nock('https://api.github.com')
         .get('/repos/toolmantim/release-drafter-test-project/releases')
@@ -1408,7 +1408,7 @@ Previous tag: ''
         return overridesTest(
           { version: '2.1.1' },
           {
-            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            body: `Placeholder with example. Automatically calculated values based on previous releases are next major=3.0.0, minor=2.1.0, patch=2.0.1. Manual input version is 2.1.1.`,
             draft: true,
             name: 'v2.1.1 (Code name: Placeholder)',
             tag_name: 'v2.1.1'
@@ -1422,7 +1422,7 @@ Previous tag: ''
         return overridesTest(
           { tag: 'v2.1.1-alpha' },
           {
-            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            body: `Placeholder with example. Automatically calculated values based on previous releases are next major=3.0.0, minor=2.1.0, patch=2.0.1. Manual input version is 2.1.1.`,
             draft: true,
             name: 'v2.1.1 (Code name: Placeholder)',
             tag_name: 'v2.1.1-alpha'
@@ -1436,7 +1436,7 @@ Previous tag: ''
         return overridesTest(
           { name: 'v2.1.1-alpha (Code name: Foxtrot Unicorn)' },
           {
-            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            body: `Placeholder with example. Automatically calculated values based on previous releases are next major=3.0.0, minor=2.1.0, patch=2.0.1. Manual input version is 2.1.1.`,
             draft: true,
             name: 'v2.1.1-alpha (Code name: Foxtrot Unicorn)',
             tag_name: 'v2.1.1'
@@ -1453,7 +1453,7 @@ Previous tag: ''
             name: 'Foxtrot Unicorn'
           },
           {
-            body: `Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.2.0, patch=2.1.1`,
+            body: `Placeholder with example. Automatically calculated values based on previous releases are next major=3.0.0, minor=2.1.0, patch=2.0.1. Manual input version is 2.1.1.`,
             draft: true,
             name: 'Foxtrot Unicorn',
             tag_name: 'v2.1.1-foxtrot-unicorn-alpha'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,6 +1260,16 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+
+check-more-types@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
+  integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+
 chokidar@^3.2.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
@@ -1621,17 +1631,17 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3882,6 +3892,11 @@ latest-version@^5.0.0:
   dependencies:
     package-json "^6.3.0"
 
+lazy-ass@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
+  integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -4336,6 +4351,16 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mocked-env@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mocked-env/-/mocked-env-1.3.2.tgz#548eb2fde141d083de70dc6b231cd9f3210d8731"
+  integrity sha512-jwm3ziowCjpbLNhUNYwn2G0tawV/ZGRuWeEGt6PItrkQT74Nk3pDldL2pmwm9sQZw6a/x+ZBGeBVYq54acTauQ==
+  dependencies:
+    check-more-types "2.24.0"
+    debug "4.1.1"
+    lazy-ass "1.6.0"
+    ramda "0.26.1"
 
 moment@^2.10.6:
   version "2.24.0"
@@ -5156,6 +5181,11 @@ querystringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
+
+ramda@0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,11 +1260,6 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-check-error@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
-
 check-more-types@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"


### PR DESCRIPTION
Allow overriding the resulting version, tag and name throught input options.
This is useful for workflows scoped by branches (https://github.com/release-drafter/release-drafter/pull/359) that need to transition a version from one branch to another - GitFlow, for example.