### PR TITLE
Prevent untagged-<hash> being set as tag name

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ module.exports = app => {
       createOrUpdateReleaseResponse = await context.github.repos.updateRelease(
         context.repo({
           release_id: draftRelease.id,
-          body: releaseInfo.body
+          body: releaseInfo.body,
+          tag_name: draftRelease.tag_name
         })
       )
     }


### PR DESCRIPTION
Set tag name in `updateRelease` parameters to keep GitHub from resetting the tag to `untagged-<hash>`.

Fixes: https://github.com/release-drafter/release-drafter/issues/204