### PR TITLE
Fix draft update from failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,6 @@ module.exports = app => {
       mergedPullRequests: sortedMergedPullRequests
     })
 
-    log({ app, context, message: draftRelease.tag_name })
-
     let createOrUpdateReleaseResponse
     if (!draftRelease) {
       log({ app, context, message: 'Creating new draft release' })

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ module.exports = app => {
       mergedPullRequests: sortedMergedPullRequests
     })
 
+    log({ app, context, message: draftRelease.tag_name })
+
     let createOrUpdateReleaseResponse
     if (!draftRelease) {
       log({ app, context, message: 'Creating new draft release' })
@@ -69,7 +71,9 @@ module.exports = app => {
         context.repo({
           release_id: draftRelease.id,
           body: releaseInfo.body,
-          tag_name: draftRelease.tag_name
+          ...(draftRelease.tag_name
+            ? { tag_name: draftRelease.tag_name }
+            : null)
         })
       )
     }


### PR DESCRIPTION
Updates to an existing draft were failing if the existing draft didn't have a tag name set. I added a check for `tag_name` on the existing draft, if it doesn't exist we don't set it instead of setting it to `null` (which is the value of `tag_name` in the previous draft if no tag name was set).