### PR TITLE
Use release tag commit date instead of released date

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -54,6 +54,35 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
   }
 `
 
+const findTagCommitTimestampQuery = /* GraphQL */ `
+  query findTagCommitTimestamp($name: String!, $owner: String!, $tag: String!) {
+    repository(name: $name, owner: $owner) {
+      object(expression: $tag) {
+        ... on Commit {
+          committedDate
+        }
+      }
+    }
+  }
+`
+
+const findTagCommitTimestamp = async ({ context, tag }) => {
+  const { owner, repo } = context.repo()
+  const variables = { name: repo, owner, tag }
+  const dataPath = ['repository', 'object', 'committedDate']
+
+  let data = await context.github.graphql(
+    findTagCommitTimestampQuery,
+    variables
+  )
+  if (!_.has(data, dataPath)) {
+    throw new Error(
+      `Data doesn't contain 'committedDate' field when querying tag '${tag}'`
+    )
+  }
+  return _.get(data, dataPath)
+}
+
 module.exports.findCommitsWithAssociatedPullRequests = async ({
   app,
   context,
@@ -66,16 +95,21 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
 
   let data
   if (lastRelease) {
+    let releaseTagTimestamp = await findTagCommitTimestamp({
+      context,
+      tag: lastRelease.tag_name
+    })
+
     log({
       app,
       context,
-      message: `Fetching all commits for branch ${branch} since ${lastRelease.published_at}`
+      message: `Fetching all commits for branch ${branch} since ${releaseTagTimestamp}`
     })
 
     data = await paginate(
       context.github.graphql,
       module.exports.findCommitsWithAssociatedPullRequestsQuery,
-      { ...variables, since: lastRelease.published_at },
+      { ...variables, since: releaseTagTimestamp },
       dataPath
     )
   } else {

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -54,8 +54,8 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
   }
 `
 
-const findTagCommitTimestampQuery = /* GraphQL */ `
-  query findTagCommitTimestamp($name: String!, $owner: String!, $tag: String!) {
+const findTagCommitDateQuery = /* GraphQL */ `
+  query findTagCommitDate($name: String!, $owner: String!, $tag: String!) {
     repository(name: $name, owner: $owner) {
       object(expression: $tag) {
         ... on Commit {
@@ -66,15 +66,12 @@ const findTagCommitTimestampQuery = /* GraphQL */ `
   }
 `
 
-const findTagCommitTimestamp = async ({ context, tag }) => {
+const findTagCommitDate = async ({ context, tag }) => {
   const { owner, repo } = context.repo()
   const variables = { name: repo, owner, tag }
   const dataPath = ['repository', 'object', 'committedDate']
 
-  let data = await context.github.graphql(
-    findTagCommitTimestampQuery,
-    variables
-  )
+  let data = await context.github.graphql(findTagCommitDateQuery, variables)
   if (!_.has(data, dataPath)) {
     throw new Error(
       `Data doesn't contain 'committedDate' field when querying tag '${tag}'`
@@ -95,7 +92,7 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
 
   let data
   if (lastRelease) {
-    let releaseTagTimestamp = await findTagCommitTimestamp({
+    let releaseTagDate = await findTagCommitDate({
       context,
       tag: lastRelease.tag_name
     })
@@ -103,13 +100,13 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
     log({
       app,
       context,
-      message: `Fetching all commits for branch ${branch} since ${releaseTagTimestamp}`
+      message: `Fetching all commits for branch ${branch} since ${releaseTagDate}`
     })
 
     data = await paginate(
       context.github.graphql,
       module.exports.findCommitsWithAssociatedPullRequestsQuery,
-      { ...variables, since: releaseTagTimestamp },
+      { ...variables, since: releaseTagDate },
       dataPath
     )
   } else {

--- a/test/fixtures/graphql-tag-v2.0.0.json
+++ b/test/fixtures/graphql-tag-v2.0.0.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "repository": {
+      "object": {
+        "committedDate": "2018-06-29T07:00:00Z"
+      }
+    }
+  }
+}

--- a/test/fixtures/release-2.json
+++ b/test/fixtures/release-2.json
@@ -31,7 +31,7 @@
   },
   "prerelease": false,
   "created_at": "2018-06-29T05:45:15Z",
-  "published_at": "2018-06-29T05:47:08Z",
+  "published_at": "2018-06-29T05:01:00Z",
   "assets": [],
   "tarball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/tarball/v1.0.0",
   "zipball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/zipball/v1.0.0",

--- a/test/fixtures/release-3.json
+++ b/test/fixtures/release-3.json
@@ -31,7 +31,7 @@
   },
   "prerelease": false,
   "created_at": "2018-06-29T05:45:15Z",
-  "published_at": "2018-06-29T05:47:08Z",
+  "published_at": "2018-06-29T06:01:00Z",
   "assets": [],
   "tarball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/tarball/v1.5.0",
   "zipball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/zipball/v1.5.0",

--- a/test/fixtures/release.json
+++ b/test/fixtures/release.json
@@ -31,7 +31,7 @@
   },
   "prerelease": false,
   "created_at": "2018-06-29T05:45:15Z",
-  "published_at": "2018-06-29T05:47:08Z",
+  "published_at": "2018-06-29T07:01:00Z",
   "assets": [],
   "tarball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/tarball/v2.0.0",
   "zipball_url": "https://api.github.com/repos/toolmantim/release-drafter-test-project/zipball/v2.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,7 +110,7 @@ describe('release-drafter', () => {
 
           nock('https://api.github.com')
             .post('/graphql', body =>
-              body.query.includes('query findTagCommitTimestamp')
+              body.query.includes('query findTagCommitDate')
             )
             .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -214,7 +214,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -274,7 +274,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -329,7 +329,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -377,7 +377,7 @@ Previous tag: ''
 
           nock('https://api.github.com')
             .post('/graphql', body =>
-              body.query.includes('query findTagCommitTimestamp')
+              body.query.includes('query findTagCommitDate')
             )
             .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -429,7 +429,7 @@ Previous tag: ''
 
           nock('https://api.github.com')
             .post('/graphql', body =>
-              body.query.includes('query findTagCommitTimestamp')
+              body.query.includes('query findTagCommitDate')
             )
             .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -482,7 +482,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -619,7 +619,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -677,7 +677,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -737,7 +737,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -796,7 +796,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -842,7 +842,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -888,7 +888,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -1384,7 +1384,7 @@ Previous tag: ''
 
       nock('https://api.github.com')
         .post('/graphql', body =>
-          body.query.includes('query findTagCommitTimestamp')
+          body.query.includes('query findTagCommitDate')
         )
         .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -1465,7 +1465,7 @@ Previous tag: ''
 
       nock('https://api.github.com')
         .post('/graphql', body =>
-          body.query.includes('query findTagCommitTimestamp')
+          body.query.includes('query findTagCommitDate')
         )
         .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -1606,7 +1606,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
@@ -1684,7 +1684,7 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
-            body.query.includes('query findTagCommitTimestamp')
+            body.query.includes('query findTagCommitDate')
           )
           .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,6 +110,12 @@ describe('release-drafter', () => {
 
           nock('https://api.github.com')
             .post('/graphql', body =>
+              body.query.includes('query findTagCommitTimestamp')
+            )
+            .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+          nock('https://api.github.com')
+            .post('/graphql', body =>
               body.query.includes('query findCommitsWithAssociatedPullRequests')
             )
             .reply(200, require('./fixtures/graphql-commits-no-prs.json'))
@@ -208,6 +214,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -244,7 +256,7 @@ Previous tag: ''
         expect.assertions(1)
       })
 
-      it('creates a new draft when run as a GitHub Actiin', async () => {
+      it('creates a new draft when run as a GitHub Action', async () => {
         getConfigMock()
 
         // GitHub actions should use the GITHUB_REF and not the payload ref
@@ -259,6 +271,12 @@ Previous tag: ''
             require('./fixtures/release'),
             require('./fixtures/release-3')
           ])
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
         nock('https://api.github.com')
           .post('/graphql', body =>
@@ -311,6 +329,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -350,6 +374,12 @@ Previous tag: ''
               '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
             )
             .reply(200, [require('./fixtures/release')])
+
+          nock('https://api.github.com')
+            .post('/graphql', body =>
+              body.query.includes('query findTagCommitTimestamp')
+            )
+            .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
           nock('https://api.github.com')
             .post('/graphql', body =>
@@ -399,6 +429,12 @@ Previous tag: ''
 
           nock('https://api.github.com')
             .post('/graphql', body =>
+              body.query.includes('query findTagCommitTimestamp')
+            )
+            .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+          nock('https://api.github.com')
+            .post('/graphql', body =>
               body.query.includes('query findCommitsWithAssociatedPullRequests')
             )
             .reply(
@@ -445,9 +481,16 @@ Previous tag: ''
           ])
 
         nock('https://api.github.com')
+          .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
           .post('/graphql', body => {
             expect(body.variables.since).toBe(
-              require('./fixtures/release-3').published_at
+              require('./fixtures/graphql-tag-v2.0.0').data.repository.object
+                .committedDate
             )
             return body.query.includes(
               'query findCommitsWithAssociatedPullRequests'
@@ -576,6 +619,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -625,6 +674,12 @@ Previous tag: ''
           .get('/repos/toolmantim/release-drafter-test-project/releases')
           .query(true)
           .reply(200, [require('./fixtures/release')])
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
         nock('https://api.github.com')
           .post('/graphql', body =>
@@ -682,6 +737,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -735,6 +796,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -775,6 +842,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(
@@ -812,6 +885,12 @@ Previous tag: ''
           .get('/repos/toolmantim/release-drafter-test-project/releases')
           .query(true)
           .reply(200, [require('./fixtures/release')])
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
         nock('https://api.github.com')
           .post('/graphql', body =>
@@ -1305,6 +1384,12 @@ Previous tag: ''
 
       nock('https://api.github.com')
         .post('/graphql', body =>
+          body.query.includes('query findTagCommitTimestamp')
+        )
+        .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+      nock('https://api.github.com')
+        .post('/graphql', body =>
           body.query.includes('query findCommitsWithAssociatedPullRequests')
         )
         .reply(200, require('./fixtures/graphql-commits-no-prs.json'))
@@ -1377,6 +1462,12 @@ Previous tag: ''
         .get('/repos/toolmantim/release-drafter-test-project/releases')
         .query(true)
         .reply(200, [require('./fixtures/release')])
+
+      nock('https://api.github.com')
+        .post('/graphql', body =>
+          body.query.includes('query findTagCommitTimestamp')
+        )
+        .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
       nock('https://api.github.com')
         .post('/graphql', body =>
@@ -1515,6 +1606,12 @@ Previous tag: ''
 
         nock('https://api.github.com')
           .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
             body.query.includes('query findCommitsWithAssociatedPullRequests')
           )
           .reply(200, require('./fixtures/graphql-commits-no-prs.json'))
@@ -1584,6 +1681,12 @@ Previous tag: ''
     describe('with previous releases, no overrides', () => {
       it('resolves to the calculated version', async () => {
         getConfigMock('config-with-resolved-version-template.yml')
+
+        nock('https://api.github.com')
+          .post('/graphql', body =>
+            body.query.includes('query findTagCommitTimestamp')
+          )
+          .reply(200, require('./fixtures/graphql-tag-v2.0.0'))
 
         nock('https://api.github.com')
           .post('/graphql', body =>


### PR DESCRIPTION
This change is about using commit date rather than Github releases published date for the basis of searching which commits should be used to fill next draft release changelog.

Github release published date is unchangeable and it is set to the creation time of the release. Even though tag is most often created with the release and their dates are same, this is not always the case, sometimes release tags have to be manipulated outside of release.

I couldn't figure a way to do this change in one GraphQL query, so I'm introducing a separate query here to fetch the commit date of the tag.

Fixes #222 