### PR TITLE
Update name and tag name in draft updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 const { getConfig } = require('./lib/config')
 const { isTriggerableBranch } = require('./lib/triggerable-branch')
-const { findReleases, generateReleaseInfo } = require('./lib/releases')
+const {
+  findReleases,
+  generateReleaseInfo,
+  createDraftRelease,
+  updateDraftRelease
+} = require('./lib/releases')
 const { findCommitsWithAssociatedPullRequests } = require('./lib/commits')
 const { sortPullRequests } = require('./lib/sort-pull-requests')
 const log = require('./lib/log')
@@ -56,26 +61,19 @@ module.exports = app => {
     let createOrUpdateReleaseResponse
     if (!draftRelease) {
       log({ app, context, message: 'Creating new draft release' })
-      createOrUpdateReleaseResponse = await context.github.repos.createRelease(
-        context.repo({
-          name: releaseInfo.name,
-          tag_name: releaseInfo.tag,
-          body: releaseInfo.body,
-          draft: true,
-          prerelease: config.prerelease
-        })
-      )
+      createOrUpdateReleaseResponse = await createDraftRelease({
+        context,
+        releaseInfo,
+        config
+      })
     } else {
       log({ app, context, message: 'Updating existing draft release' })
-      createOrUpdateReleaseResponse = await context.github.repos.updateRelease(
-        context.repo({
-          release_id: draftRelease.id,
-          body: releaseInfo.body,
-          ...(draftRelease.tag_name
-            ? { tag_name: draftRelease.tag_name }
-            : null)
-        })
-      )
+      createOrUpdateReleaseResponse = await updateDraftRelease({
+        context,
+        draftRelease,
+        releaseInfo,
+        config
+      })
     }
 
     setActionOutput(createOrUpdateReleaseResponse)

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -218,3 +218,49 @@ module.exports.generateReleaseInfo = ({
     body
   }
 }
+
+module.exports.createDraftRelease = ({ context, releaseInfo, config }) => {
+  return context.github.repos.createRelease(
+    context.repo({
+      name: releaseInfo.name,
+      tag_name: releaseInfo.tag,
+      body: releaseInfo.body,
+      draft: true,
+      prerelease: config.prerelease
+    })
+  )
+}
+
+module.exports.updateDraftRelease = ({
+  context,
+  draftRelease,
+  releaseInfo,
+  config
+}) => {
+  const updateReleaseParams = updateDraftReleaseParams({
+    name: releaseInfo.name || draftRelease.name,
+    tag_name: releaseInfo.tag || draftRelease.tag_name
+  })
+
+  return context.github.repos.updateRelease(
+    context.repo({
+      release_id: draftRelease.id,
+      body: releaseInfo.body,
+      ...updateReleaseParams
+    })
+  )
+}
+
+function updateDraftReleaseParams(params) {
+  const updateReleaseParams = { ...params }
+
+  // Let GitHub figure out `name` and `tag_name` if undefined
+  if (!updateReleaseParams.name) {
+    delete updateReleaseParams.name
+  }
+  if (!updateReleaseParams.tag_name) {
+    delete updateReleaseParams.tag_name
+  }
+
+  return updateReleaseParams
+}


### PR DESCRIPTION
Fixes the issue described here: https://github.com/release-drafter/release-drafter/pull/363#issuecomment-576886932

After thinking about it I don't think we should provide a config option for it. If you opt-in to having Release Drafter generate version numbers, you can expect it to override the tag and the release name. I consider not doing so as a bug.