### PR TITLE
Calculate resolved version based on increment config

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -78,22 +78,22 @@ const contributorsSentence = ({ commits, pullRequests }) => {
   }
 }
 
-const categorizePullRequests = (pullRequests, config) => {
-  const { 'exclude-labels': excludeLabels, categories } = config
-  const allCategoryLabels = categories.flatMap(category => category.labels)
-  const uncategorizedPullRequests = []
-  const categorizedPullRequests = [...categories].map(category => {
-    return { ...category, pullRequests: [] }
-  })
-
-  const filterExcludedPullRequests = pullRequest => {
+const getIncludedPullRequests = (pullRequests, config) => {
+  return pullRequests.filter(pullRequest => {
     const labels = pullRequest.labels.nodes
 
-    if (labels.some(label => excludeLabels.includes(label.name))) {
-      return false
-    }
-    return true
-  }
+    return !labels.some(label => config['exclude-labels'].includes(label.name))
+  })
+}
+
+const categorizePullRequests = (pullRequests, config) => {
+  const allCategoryLabels = config.categories.flatMap(
+    category => category.labels
+  )
+  const uncategorizedPullRequests = []
+  const categorizedPullRequests = [...config.categories].map(category => {
+    return { ...category, pullRequests: [] }
+  })
 
   const filterUncategorizedPullRequests = pullRequest => {
     const labels = pullRequest.labels.nodes
@@ -109,9 +109,10 @@ const categorizePullRequests = (pullRequests, config) => {
   }
 
   // we only want pull requests that have yet to be categorized
-  const filteredPullRequests = pullRequests
-    .filter(filterExcludedPullRequests)
-    .filter(filterUncategorizedPullRequests)
+  const filteredPullRequests = getIncludedPullRequests(
+    pullRequests,
+    config
+  ).filter(filterUncategorizedPullRequests)
 
   categorizedPullRequests.map(category => {
     filteredPullRequests.map(pullRequest => {
@@ -126,6 +127,37 @@ const categorizePullRequests = (pullRequests, config) => {
   })
 
   return [uncategorizedPullRequests, categorizedPullRequests]
+}
+
+const resolveIncrement = (pullRequests, config) => {
+  const fallback = 'PATCH'
+
+  if (!config.increment) {
+    return fallback
+  }
+
+  pullRequests = getIncludedPullRequests(pullRequests, config)
+
+  const usedLabels = pullRequests.flatMap(pullRequest =>
+    pullRequest.labels.nodes.map(label => label.name)
+  )
+
+  if (!usedLabels.length) {
+    return fallback
+  }
+
+  const areIncrementLabelsUsed = incrementLabels =>
+    incrementLabels.some(label => usedLabels.includes(label))
+
+  if (areIncrementLabelsUsed(config.increment['major-labels'])) {
+    return 'MAJOR'
+  }
+
+  if (areIncrementLabelsUsed(config.increment['minor-labels'])) {
+    return 'MINOR'
+  }
+
+  return fallback
 }
 
 const generateChangeLog = (mergedPullRequests, config) => {
@@ -193,12 +225,20 @@ module.exports.generateReleaseInfo = ({
     config.replacers
   )
 
+  // identify an input version, from the most accurate override parameter to
+  // the least
+  const inputVersion = version || tag || name
+
+  // resolve the increment, unless an input version has been specified
+  const increment = inputVersion
+    ? null
+    : resolveIncrement(mergedPullRequests, config)
+
   const versionInfo = getVersionInfo(
     lastRelease,
     config['version-template'],
-    // Use the first override parameter to identify
-    // a version, from the most accurate to the least
-    version || tag || name
+    inputVersion,
+    increment
   )
 
   if (versionInfo) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -77,6 +77,17 @@ const schema = context => {
       )
       .default(DEFAULT_CONFIG.categories),
 
+    increment: Joi.object().keys({
+      'major-labels': Joi.array()
+        .items(Joi.string())
+        .single()
+        .default([]),
+      'minor-labels': Joi.array()
+        .items(Joi.string())
+        .single()
+        .default([])
+    }),
+
     template: Joi.string().required(),
 
     _extends: Joi.string()

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -27,8 +27,17 @@ const getTemplatableVersion = input => {
     $RESOLVED_VERSION: null
   }
 
-  templatableVersion.$RESOLVED_VERSION =
-    templatableVersion.$INPUT_VERSION || templatableVersion.$NEXT_PATCH_VERSION
+  // Resolve: input version -> incremented version -> next patch version
+
+  if (templatableVersion.$INPUT_VERSION) {
+    templatableVersion.$RESOLVED_VERSION = templatableVersion.$INPUT_VERSION
+  } else if (input.increment) {
+    templatableVersion.$RESOLVED_VERSION =
+      templatableVersion[`$NEXT_${input.increment}_VERSION`]
+  } else {
+    templatableVersion.$RESOLVED_VERSION =
+      templatableVersion.$NEXT_PATCH_VERSION
+  }
 
   return templatableVersion
 }
@@ -43,7 +52,12 @@ const coerceVersion = input => {
     : semver.coerce(input)
 }
 
-module.exports.getVersionInfo = (release, template, inputVersion = null) => {
+module.exports.getVersionInfo = (
+  release,
+  template,
+  inputVersion = null,
+  increment = null
+) => {
   const version = coerceVersion(release)
   inputVersion = coerceVersion(inputVersion)
 
@@ -55,7 +69,8 @@ module.exports.getVersionInfo = (release, template, inputVersion = null) => {
     ...getTemplatableVersion({
       version,
       template,
-      inputVersion
+      inputVersion,
+      increment
     })
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -107,6 +107,7 @@
             "type": "string"
           },
           "labels": {
+            "default": [],
             "type": "array",
             "items": {
               "type": "string"
@@ -117,6 +118,27 @@
         "patterns": [],
         "required": ["title"]
       }
+    },
+    "increment": {
+      "type": "object",
+      "properties": {
+        "major-labels": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minor-labels": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "patterns": []
     },
     "template": {
       "type": "string"

--- a/test/fixtures/config/config-with-resolved-version-template-increment.yml
+++ b/test/fixtures/config/config-with-resolved-version-template-increment.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+branches:
+  - master
+categories:
+  - title: '🚀 Features'
+    label: 'feature'
+  - title: '🐛 Bug fixes'
+    label: 'bug'
+  - title: '📄 Documentation'
+    label: 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'maintenance'
+increment:
+  major-labels:
+    - 'breaking'
+    - 'breaking-changes'
+  minor-labels: 'feature'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  ## Previous release
+
+  $PREVIOUS_TAG

--- a/test/fixtures/graphql-commits-breaking-changes.json
+++ b/test/fixtures/graphql-commits-breaking-changes.json
@@ -1,0 +1,164 @@
+{
+  "data": {
+    "repository": {
+      "ref": {
+        "target": {
+          "history": {
+            "totalCount": 120,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "d1d78f7d126c56c7165213cd2dffddcbc8cee8b6 99"
+            },
+            "nodes": [
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjI1MzQ0MDhmZWI4MzZkYWNjNTFlYzdjMGFmNGYyNDdlN2JlMzlkNzQ=",
+                "message": "Merge pull request #3 from TimonVS/fix/bug-fixes\n\nBug fixes",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjQ4ZTkwNTYwNWQ4ODkyNWI1MjJjMmIwMGY2NDZmNzQ0ZmQ5NzZkMjE=",
+                "message": "Merge pull request #2 from TimonVS/feature/big-feature\n\nAdd big feature",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add big feature with breaking changes",
+                      "number": 2,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:39Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "breaking-changes"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTM4NzMyNDgxOjdmOGY4NjI3NDY3ZTQwMDhmM2Q0NmE3ZWUwMmJmYWRlZGFmZjM4ZWU=",
+                "message": "Update README.md",
+                "author": {
+                  "name": "Tim Lucas",
+                  "user": {
+                    "login": "toolmantim"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Added great distance",
+                      "number": 16,
+                      "mergedAt": "2018-07-13T11:50:38Z",
+                      "author": {
+                        "login": "toolmantim"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjVmNTViZThiOTA2M2IzOWQ5Y2VkYzllNWRkOGZkMDIyMjFiZDMxZjQ=",
+                "message": "Merge pull request #1 from TimonVS/feature/alien-technology\n\n👽 Add alien technology",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "👽 Add alien technology",
+                      "number": 1,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:29Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjFiYmJiM2FhYWFmMTk3MDYyYmRmMjg2ODhiMDk4NTI0NjcxM2NkMTI=",
+                "message": "Fixed another bug",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/graphql-commits-features-and-fixes.json
+++ b/test/fixtures/graphql-commits-features-and-fixes.json
@@ -1,0 +1,134 @@
+{
+  "data": {
+    "repository": {
+      "ref": {
+        "target": {
+          "history": {
+            "totalCount": 120,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "d1d78f7d126c56c7165213cd2dffddcbc8cee8b6 99"
+            },
+            "nodes": [
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjI1MzQ0MDhmZWI4MzZkYWNjNTFlYzdjMGFmNGYyNDdlN2JlMzlkNzQ=",
+                "message": "Merge pull request #3 from TimonVS/fix/bug-fixes\n\nBug fixes",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTM4NzMyNDgxOjdmOGY4NjI3NDY3ZTQwMDhmM2Q0NmE3ZWUwMmJmYWRlZGFmZjM4ZWU=",
+                "message": "Update README.md",
+                "author": {
+                  "name": "Tim Lucas",
+                  "user": {
+                    "login": "toolmantim"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Added great distance",
+                      "number": 16,
+                      "mergedAt": "2018-07-13T11:50:38Z",
+                      "author": {
+                        "login": "toolmantim"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjVmNTViZThiOTA2M2IzOWQ5Y2VkYzllNWRkOGZkMDIyMjFiZDMxZjQ=",
+                "message": "Merge pull request #1 from TimonVS/feature/alien-technology\n\n👽 Add alien technology",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "👽 Add alien technology",
+                      "number": 1,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:29Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjFiYmJiM2FhYWFmMTk3MDYyYmRmMjg2ODhiMDk4NTI0NjcxM2NkMTI=",
+                "message": "Fixed another bug",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/graphql-commits-only-fixes-or-no-label.json
+++ b/test/fixtures/graphql-commits-only-fixes-or-no-label.json
@@ -1,0 +1,104 @@
+{
+  "data": {
+    "repository": {
+      "ref": {
+        "target": {
+          "history": {
+            "totalCount": 120,
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": "d1d78f7d126c56c7165213cd2dffddcbc8cee8b6 99"
+            },
+            "nodes": [
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjI1MzQ0MDhmZWI4MzZkYWNjNTFlYzdjMGFmNGYyNDdlN2JlMzlkNzQ=",
+                "message": "Merge pull request #3 from TimonVS/fix/bug-fixes\n\nBug fixes",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTM4NzMyNDgxOjdmOGY4NjI3NDY3ZTQwMDhmM2Q0NmE3ZWUwMmJmYWRlZGFmZjM4ZWU=",
+                "message": "Update README.md",
+                "author": {
+                  "name": "Tim Lucas",
+                  "user": {
+                    "login": "toolmantim"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Added great distance",
+                      "number": 16,
+                      "mergedAt": "2018-07-13T11:50:38Z",
+                      "author": {
+                        "login": "toolmantim"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjFiYmJiM2FhYWFmMTk3MDYyYmRmMjg2ODhiMDk4NTI0NjcxM2NkMTI=",
+                "message": "Fixed another bug",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "isCrossRepository": false,
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This makes the `$RESOLVED_VERSION` template variable to use the next patch/minor/major calculated version, depending on the PR types since the last release.

It is possible to configure the increment in the config file:
```yml
increment:
  major-labels:
    - 'breaking'
    - 'breaking-changes'
  minor-labels: 'feature'
```

So, if there is any PR with the configured major-labels, the `$RESOLVED_VERSION` will be the next major. If not, it checks the same for minor-labels, resolving to the next minor.
In any other case (didn't match those labels or not configured at all), it falls back to the next patch version (the current behaviour in master).