### PR TITLE
Allow adding the body of the PR to the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can use any of the following variables in `change-template`:
 | `$NUMBER` | The number of the pull request, e.g. `42`.                  |
 | `$TITLE`  | The title of the pull request, e.g. `Add alien technology`. |
 | `$AUTHOR` | The pull request author’s username, e.g. `gracehopper`.     |
+| `$BODY`   | The body of the pull request e.g. `Fixed spelling mistake`. |
 
 ## Categorize Pull Requests
 

--- a/bin/generate-fixtures.js
+++ b/bin/generate-fixtures.js
@@ -36,6 +36,7 @@ branches.forEach((branch) => {
         owner: REPO_OWNER,
         name: REPO_NAME,
         branch,
+        withPullRequestBody: true
       },
     }),
   }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = (app) => {
       context,
       branch,
       lastRelease,
+      config,
     })
 
     const sortedMergedPullRequests = sortPullRequests(

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -33,6 +33,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   nodes {
                     title
                     number
+                    body
                     author {
                       login
                     }

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -7,6 +7,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
     $name: String!
     $owner: String!
     $branch: String!
+    $withPullRequestBody: Boolean!
     $since: GitTimestamp
     $after: String
   ) {
@@ -33,7 +34,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   nodes {
                     title
                     number
-                    body
+                    body @include(if: $withPullRequestBody)
                     author {
                       login
                     }
@@ -60,9 +61,15 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
   context,
   branch,
   lastRelease,
+  config,
 }) => {
   const { owner, repo } = context.repo()
-  const variables = { name: repo, owner, branch }
+  const variables = {
+    name: repo,
+    owner,
+    branch,
+    withPullRequestBody: config['change-template'].includes('$BODY'),
+  }
   const dataPath = ['repository', 'ref', 'target', 'history']
 
   let data

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -158,6 +158,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
           $TITLE: pullRequest.title,
           $NUMBER: pullRequest.number,
           $AUTHOR: pullRequest.author ? pullRequest.author.login : 'ghost',
+          $BODY: pullRequest.body,
         })
       )
       .join('\n')

--- a/test/fixtures/__generated__/graphql-commits-merge-commit.json
+++ b/test/fixtures/__generated__/graphql-commits-merge-commit.json
@@ -24,6 +24,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -54,6 +55,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -80,6 +82,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -110,6 +113,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -140,6 +144,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 1,
+                      "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -170,6 +175,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -200,6 +206,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -230,6 +237,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -256,6 +264,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -282,6 +291,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -312,6 +322,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -342,6 +353,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -372,6 +384,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -402,6 +415,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 1,
+                      "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"
                       },

--- a/test/fixtures/__generated__/graphql-commits-overlapping-label.json
+++ b/test/fixtures/__generated__/graphql-commits-overlapping-label.json
@@ -16,7 +16,7 @@
                 "author": {
                   "name": "Joseph Petersen",
                   "user": {
-                    "login": "casz"
+                    "login": "jetersen"
                   }
                 },
                 "associatedPullRequests": {
@@ -24,8 +24,9 @@
                     {
                       "title": "Add documentation",
                       "number": 22,
+                      "body": "✍️ writing docs all",
                       "author": {
-                        "login": "casz"
+                        "login": "jetersen"
                       },
                       "mergedAt": "2020-02-02T13:55:50Z",
                       "isCrossRepository": false,
@@ -46,7 +47,7 @@
                 "author": {
                   "name": "Joseph Petersen",
                   "user": {
-                    "login": "casz"
+                    "login": "jetersen"
                   }
                 },
                 "associatedPullRequests": {
@@ -54,8 +55,9 @@
                     {
                       "title": "Update dependencies",
                       "number": 21,
+                      "body": "📦 Package time! 📦",
                       "author": {
-                        "login": "casz"
+                        "login": "jetersen"
                       },
                       "mergedAt": "2020-02-02T13:55:28Z",
                       "isCrossRepository": false,
@@ -72,7 +74,7 @@
                 "author": {
                   "name": "Joseph Petersen",
                   "user": {
-                    "login": "casz"
+                    "login": "jetersen"
                   }
                 },
                 "associatedPullRequests": {
@@ -80,8 +82,9 @@
                     {
                       "title": "Bug fixes",
                       "number": 20,
+                      "body": "🐛 squashing",
                       "author": {
-                        "login": "casz"
+                        "login": "jetersen"
                       },
                       "mergedAt": "2020-02-02T13:55:11Z",
                       "isCrossRepository": false,
@@ -105,7 +108,7 @@
                 "author": {
                   "name": "Joseph Petersen",
                   "user": {
-                    "login": "casz"
+                    "login": "jetersen"
                   }
                 },
                 "associatedPullRequests": {
@@ -113,8 +116,9 @@
                     {
                       "title": "Add big feature",
                       "number": 19,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
-                        "login": "casz"
+                        "login": "jetersen"
                       },
                       "mergedAt": "2020-02-02T13:54:54Z",
                       "isCrossRepository": false,
@@ -135,7 +139,7 @@
                 "author": {
                   "name": "Joseph Petersen",
                   "user": {
-                    "login": "casz"
+                    "login": "jetersen"
                   }
                 },
                 "associatedPullRequests": {
@@ -143,8 +147,9 @@
                     {
                       "title": "Add alien technology",
                       "number": 18,
+                      "body": "",
                       "author": {
-                        "login": "casz"
+                        "login": "jetersen"
                       },
                       "mergedAt": "2020-02-02T13:54:23Z",
                       "isCrossRepository": false,

--- a/test/fixtures/__generated__/graphql-commits-rebase-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-rebase-merging.json
@@ -24,6 +24,7 @@
                     {
                       "title": "Add documentation",
                       "number": 10,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -54,6 +55,7 @@
                     {
                       "title": "Add documentation",
                       "number": 10,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -84,6 +86,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 9,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -110,6 +113,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 9,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -136,6 +140,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 8,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -166,6 +171,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 8,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -196,6 +202,7 @@
                     {
                       "title": "Add big feature",
                       "number": 7,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -226,6 +233,7 @@
                     {
                       "title": "Add big feature",
                       "number": 7,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -256,6 +264,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 6,
+                      "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"
                       },

--- a/test/fixtures/__generated__/graphql-commits-squash-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-squash-merging.json
@@ -24,6 +24,7 @@
                     {
                       "title": "Add documentation",
                       "number": 15,
+                      "body": "✍️ writing docs all",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -54,6 +55,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 14,
+                      "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -80,6 +82,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 13,
+                      "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -110,6 +113,7 @@
                     {
                       "title": "Add big feature",
                       "number": 12,
+                      "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -140,6 +144,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 11,
+                      "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"
                       },

--- a/test/fixtures/config/config-with-changes-templates-and-body.yml
+++ b/test/fixtures/config/config-with-changes-templates-and-body.yml
@@ -1,0 +1,3 @@
+template: '$CHANGES'
+no-changes-template: '* No changes mmkay'
+change-template: "* Change: #$NUMBER '$TITLE' $BODY"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -385,6 +385,52 @@ Previous tag: ''
         })
       })
 
+      describe('with custom changes-template config that includes a pull request body', () => {
+        it('creates a new draft using the template', async () => {
+          getConfigMock('config-with-changes-templates-and-body.yml')
+
+          nock('https://api.github.com')
+            .get(
+              '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+            )
+            .reply(200, [require('./fixtures/release')])
+
+          nock('https://api.github.com')
+            .post('/graphql', (body) =>
+              body.query.includes('query findCommitsWithAssociatedPullRequests')
+            )
+            .reply(
+              200,
+              require('./fixtures/__generated__/graphql-commits-merge-commit.json')
+            )
+
+          nock('https://api.github.com')
+            .post(
+              '/repos/toolmantim/release-drafter-test-project/releases',
+              (body) => {
+                expect(body).toMatchObject({
+                  body: `* Change: #5 'Add documentation' ✍️ writing docs all
+* Change: #4 'Update dependencies' 📦 Package time! 📦
+* Change: #3 'Bug fixes' 🐛 squashing
+* Change: #2 'Add big feature' ![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)
+* Change: #1 '👽 Add alien technology' Space invasion 👾`,
+                  draft: true,
+                  tag_name: '',
+                })
+                return true
+              }
+            )
+            .reply(200, require('./fixtures/release'))
+
+          await probot.receive({
+            name: 'push',
+            payload: require('./fixtures/push'),
+          })
+
+          expect.assertions(1)
+        })
+      })
+
       describe('with contributors config', () => {
         it('adds the contributors', async () => {
           getConfigMock('config-with-contributors.yml')
@@ -693,17 +739,17 @@ Previous tag: ''
                 Object {
                   "body": "# What's Changed
 
-                * Add documentation (#22) @casz
-                * Update dependencies (#21) @casz
+                * Add documentation (#22) @jetersen
+                * Update dependencies (#21) @jetersen
 
                 ## 🚀 Features
 
-                * Add big feature (#19) @casz
-                * Add alien technology (#18) @casz
+                * Add big feature (#19) @jetersen
+                * Add alien technology (#18) @jetersen
 
                 ## 🐛 Bug Fixes
 
-                * Bug fixes (#20) @casz
+                * Bug fixes (#20) @jetersen
                 ",
                   "draft": true,
                   "name": "",
@@ -749,21 +795,21 @@ Previous tag: ''
                 Object {
                   "body": "# What's Changed
 
-                * Add documentation (#22) @casz
-                * Update dependencies (#21) @casz
+                * Add documentation (#22) @jetersen
+                * Update dependencies (#21) @jetersen
 
                 ## 🚀 Features
 
-                * Add big feature (#19) @casz
-                * Add alien technology (#18) @casz
+                * Add big feature (#19) @jetersen
+                * Add alien technology (#18) @jetersen
 
                 ## 🐛 Bug Fixes
 
-                * Bug fixes (#20) @casz
+                * Bug fixes (#20) @jetersen
 
                 ## 🎖️ Sentry
 
-                * Bug fixes (#20) @casz
+                * Bug fixes (#20) @jetersen
                 ",
                   "draft": true,
                   "name": "",


### PR DESCRIPTION
We make extensive use of the pull request body and automatically send out the release body to a group of people when the release is deployed.

As such I would like to stop having to copy the PR body manually into the release notes. 

I have added a test however it is not very good because I think I need to be a PR in this [repo]( https://github.com/TimonVS/release-drafter-test-repo) with a body to do a proper test. If there is a way to get that or another way to add a test body please do let me know.

fixes #517 