### PR TITLE
Set the release name and tag_name as outputs of the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ The Release Drafter GitHub Action sets a couple of outputs which can be used as 
 | Output       | Description                                                                                                                                                                                                                   |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`         | The ID of the release that was created or updated.                                                                                                                                                                            |
+| `name`       | The name of this release.
+| `tag_name`   | The name of the tag associated with this release.
 | `html_url`   | The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`.                                                                                                    |
 | `upload_url` | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset GitHub Action`](https://www.github.com/actions/upload-release-asset). |
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `branches`            | Optional | The branches to listen for configuration updates to `.github/release-drafter.yml` and for merge commits. Useful if you want to test the app on a pull request branch. Default is the repository’s default branch. |
 | `categories`          | Optional | Categorize pull requests using labels. Refer to [Categorize Pull Requests](#categorize-pull-requests) to learn more about this option.                                                                            |
 | `exclude-labels`      | Optional | Exclude pull requests using labels. Refer to [Exclude Pull Requests](#exclude-pull-requests) to learn more about this option.                                                                                     |
-| `include-labels`      | Optional | Include only the specified pull requests using labels. Refer to [Include Pull Requests](#include-pull-requests) to learn more about this option.                                                                                     |
+| `include-labels`      | Optional | Include only the specified pull requests using labels. Refer to [Include Pull Requests](#include-pull-requests) to learn more about this option.                                                                  |
 | `replacers`           | Optional | Search and replace content in the generated changelog body. Refer to [Replacers](#replacers) to learn more about this option.                                                                                     |
 | `sort-by`             | Optional | Sort changelog by merged_at or title. Can be one of: `merged_at`, `title`. Default: `merged_at`.                                                                                                                  |
 | `sort-direction`      | Optional | Sort changelog in ascending or descending order. Can be one of: `ascending`, `descending`. Default: `descending`.                                                                                                 |
@@ -175,7 +175,7 @@ Pull requests with the label "skip-changelog" will now be excluded from the rele
 
 ## Include Pull Requests
 
-With the `include-labels` option you can specify pull requests from the release notes using labels. Only pull requests that have the configured labels will be included in the pull request.  For example, append the following to your `.github/release-drafter.yml` file:
+With the `include-labels` option you can specify pull requests from the release notes using labels. Only pull requests that have the configured labels will be included in the pull request. For example, append the following to your `.github/release-drafter.yml` file:
 
 ```yml
 include-labels:
@@ -219,8 +219,8 @@ The Release Drafter GitHub Action sets a couple of outputs which can be used as 
 | Output       | Description                                                                                                                                                                                                                   |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`         | The ID of the release that was created or updated.                                                                                                                                                                            |
-| `name`       | The name of this release.
-| `tag_name`   | The name of the tag associated with this release.
+| `name`       | The name of this release.                                                                                                                                                                                                     |
+| `tag_name`   | The name of the tag associated with this release.                                                                                                                                                                             |
 | `html_url`   | The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`.                                                                                                    |
 | `upload_url` | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset GitHub Action`](https://www.github.com/actions/upload-release-asset). |
 

--- a/index.js
+++ b/index.js
@@ -87,10 +87,12 @@ module.exports = (app) => {
 
 function setActionOutput(releaseResponse) {
   const {
-    data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl },
+    data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl, tag_name: tagName, name: name },
   } = releaseResponse
   if (releaseId && Number.isInteger(releaseId))
     core.setOutput('id', releaseId.toString())
   if (htmlUrl) core.setOutput('html_url', htmlUrl)
   if (uploadUrl) core.setOutput('upload_url', uploadUrl)
+  if (tagName) core.setOutput('tag_name', tagName)
+  if (name) core.setOutput('name', name)
 }


### PR DESCRIPTION
This is necessary if you are planning to execute additional steps after creating the release draft. As the release name and tag are autogenerated, it is essential that the action provides these.