### PR TITLE
Update example in README to use version resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ As pull requests are merged, a draft release is kept up-to-date listing the chan
 The following is a more complicated configuration, which categorises the changes into headings, and automatically suggests the next version number:
 
 ```yml
-name-template: 'v$NEXT_PATCH_VERSION 🌈'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
The configuration example in `README.md` has a `version-resolver` section with labels that supposed to control the version name / tag strings. However, this example dos not work out of the box, which could be frustrating, especially for new users.

This tiny PR is to update name/tag templates with `$RESOLVED_VERSION`, so the version labels, if present, will actually be used.