### PR TITLE
Allow adding the URL of the PR to the release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,13 @@ If a pull requests is found with the label `major`/`minor`/`patch`, the correspo
 
 You can use any of the following variables in `change-template`:
 
-| Variable  | Description                                                 |
-| --------- | ----------------------------------------------------------- |
-| `$NUMBER` | The number of the pull request, e.g. `42`.                  |
-| `$TITLE`  | The title of the pull request, e.g. `Add alien technology`. |
-| `$AUTHOR` | The pull request author’s username, e.g. `gracehopper`.     |
-| `$BODY`   | The body of the pull request e.g. `Fixed spelling mistake`. |
+| Variable  | Description                                                                 |
+| --------- | --------------------------------------------------------------------------- |
+| `$NUMBER` | The number of the pull request, e.g. `42`.                                  |
+| `$TITLE`  | The title of the pull request, e.g. `Add alien technology`.                 |
+| `$AUTHOR` | The pull request author’s username, e.g. `gracehopper`.                     |
+| `$BODY`   | The body of the pull request e.g. `Fixed spelling mistake`.                 |
+| `$URL`    | The URL of the pull request e.g. `https://github.com/octocat/repo/pull/42`. |
 
 ## References
 

--- a/bin/generate-fixtures.js
+++ b/bin/generate-fixtures.js
@@ -52,6 +52,7 @@ repos.forEach((repo) => {
         name: REPO_NAME,
         ref: repo.branch,
         withPullRequestBody: true,
+        withPullRequestURL: true,
       },
     }),
   }

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -35,6 +35,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   nodes {
                     title
                     number
+                    url
                     body @include(if: $withPullRequestBody)
                     author {
                       login

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -8,6 +8,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
     $owner: String!
     $ref: String!
     $withPullRequestBody: Boolean!
+    $withPullRequestURL: Boolean!
     $since: GitTimestamp
     $after: String
   ) {
@@ -35,7 +36,7 @@ module.exports.findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   nodes {
                     title
                     number
-                    url
+                    url @include(if: $withPullRequestURL)
                     body @include(if: $withPullRequestBody)
                     author {
                       login
@@ -74,6 +75,7 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
     owner,
     ref,
     withPullRequestBody: config['change-template'].includes('$BODY'),
+    withPullRequestURL: config['change-template'].includes('$URL'),
   }
   const dataPath = ['repository', 'ref', 'target', 'history']
   const repoNameWithOwner = `${owner}/${repo}`

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -163,6 +163,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
           $NUMBER: pullRequest.number,
           $AUTHOR: pullRequest.author ? pullRequest.author.login : 'ghost',
           $BODY: pullRequest.body,
+          $URL: pullRequest.url,
         })
       )
       .join('\n')

--- a/test/fixtures/__generated__/graphql-commits-forking.json
+++ b/test/fixtures/__generated__/graphql-commits-forking.json
@@ -25,6 +25,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -56,6 +57,7 @@
                     {
                       "title": "Add documentation",
                       "number": 28,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/28",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "jetersen"
@@ -76,6 +78,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -107,6 +110,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 27,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/27",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "jetersen"
@@ -123,6 +127,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -154,6 +159,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 25,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/25",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "jetersen"
@@ -177,6 +183,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -208,6 +215,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 25,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/25",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "jetersen"
@@ -231,6 +239,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -262,6 +271,7 @@
                     {
                       "title": "Add big feature",
                       "number": 24,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/24",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "jetersen"
@@ -285,6 +295,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -316,6 +327,7 @@
                     {
                       "title": "Add alien technology",
                       "number": 23,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/23",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "jetersen"
@@ -339,6 +351,7 @@
                     {
                       "title": "🙅‍♂️ Forking PR 🙅‍♂️",
                       "number": 1,
+                      "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                       "body": "No thanks to forking PRs",
                       "author": {
                         "login": "jetersen"
@@ -370,6 +383,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -405,6 +419,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -440,6 +455,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -471,6 +487,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -502,6 +519,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 1,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"

--- a/test/fixtures/__generated__/graphql-commits-merge-commit.json
+++ b/test/fixtures/__generated__/graphql-commits-merge-commit.json
@@ -25,6 +25,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -60,6 +61,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -91,6 +93,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -129,6 +132,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -167,6 +171,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 1,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"
@@ -202,6 +207,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -237,6 +243,7 @@
                     {
                       "title": "Add documentation",
                       "number": 5,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -272,6 +279,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -303,6 +311,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 4,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -334,6 +343,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -372,6 +382,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 3,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -410,6 +421,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -448,6 +460,7 @@
                     {
                       "title": "Add big feature",
                       "number": 2,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -486,6 +499,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 1,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"

--- a/test/fixtures/__generated__/graphql-commits-overlapping-label.json
+++ b/test/fixtures/__generated__/graphql-commits-overlapping-label.json
@@ -25,6 +25,7 @@
                     {
                       "title": "Add documentation",
                       "number": 22,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/22",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "jetersen"
@@ -60,6 +61,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 21,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/21",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "jetersen"
@@ -91,6 +93,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 20,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/20",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "jetersen"
@@ -132,6 +135,7 @@
                     {
                       "title": "Add big feature",
                       "number": 19,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/19",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "jetersen"
@@ -170,6 +174,7 @@
                     {
                       "title": "Add alien technology",
                       "number": 18,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/18",
                       "body": "",
                       "author": {
                         "login": "jetersen"

--- a/test/fixtures/__generated__/graphql-commits-rebase-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-rebase-merging.json
@@ -25,6 +25,7 @@
                     {
                       "title": "Add documentation",
                       "number": 10,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/10",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -60,6 +61,7 @@
                     {
                       "title": "Add documentation",
                       "number": 10,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/10",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -95,6 +97,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 9,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/9",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -126,6 +129,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 9,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/9",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -157,6 +161,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 8,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/8",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -195,6 +200,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 8,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/8",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -233,6 +239,7 @@
                     {
                       "title": "Add big feature",
                       "number": 7,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/7",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -271,6 +278,7 @@
                     {
                       "title": "Add big feature",
                       "number": 7,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/7",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -309,6 +317,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 6,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/6",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"

--- a/test/fixtures/__generated__/graphql-commits-squash-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-squash-merging.json
@@ -25,6 +25,7 @@
                     {
                       "title": "Add documentation",
                       "number": 15,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/15",
                       "body": "✍️ writing docs all day",
                       "author": {
                         "login": "TimonVS"
@@ -60,6 +61,7 @@
                     {
                       "title": "Update dependencies",
                       "number": 14,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/14",
                       "body": "📦 Package time! 📦",
                       "author": {
                         "login": "TimonVS"
@@ -91,6 +93,7 @@
                     {
                       "title": "Bug fixes",
                       "number": 13,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/13",
                       "body": "🐛 squashing",
                       "author": {
                         "login": "TimonVS"
@@ -129,6 +132,7 @@
                     {
                       "title": "Add big feature",
                       "number": 12,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/12",
                       "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                       "author": {
                         "login": "TimonVS"
@@ -167,6 +171,7 @@
                     {
                       "title": "👽 Add alien technology",
                       "number": 11,
+                      "url": "https://github.com/toolmantim/release-drafter-test-project/pull/11",
                       "body": "Space invasion 👾",
                       "author": {
                         "login": "TimonVS"

--- a/test/fixtures/config/config-with-changes-templates-and-url.yml
+++ b/test/fixtures/config/config-with-changes-templates-and-url.yml
@@ -1,0 +1,3 @@
+template: '$CHANGES'
+no-changes-template: '* No changes mmkay'
+change-template: "* Change: $URL '$TITLE' @$AUTHOR"


### PR DESCRIPTION
We are actively uses a repo's release notes in scope of other repos.  
This makes a github PR's short link (`#NUMBER`) lead to a wrong place.

So I would like to have an option to use an issue's complete URL instead of hardcoded replacements.