### PR TITLE
Allow more than just a push event to run the action

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const log = require('./lib/log')
 const core = require('@actions/core')
 
 module.exports = (app) => {
-  app.on('push', async (context) => {
+  app.on('*', async (context) => {
     const { shouldDraft, configName, version, tag, name } = getInput()
 
     const config = await getConfig({

--- a/index.js
+++ b/index.js
@@ -10,9 +10,12 @@ const { findCommitsWithAssociatedPullRequests } = require('./lib/commits')
 const { sortPullRequests } = require('./lib/sort-pull-requests')
 const log = require('./lib/log')
 const core = require('@actions/core')
+const { runnerIsActions } = require('./lib/utils')
 
 module.exports = (app) => {
-  app.on('*', async (context) => {
+  const event = runnerIsActions() ? '*' : 'push'
+
+  app.on(event, async (context) => {
     const { shouldDraft, configName, version, tag, name } = getInput()
 
     const config = await getConfig({


### PR DESCRIPTION
We would like to propose a change, where it is the github action determines, when a release-drafter should be run.
We have a usecase, where it is a workflow dispatch event, that triggers the action and this line: ```app.on('push', async (context) => {``` prevents the action to run. 

Maybe there is a better way to solve this problem rather than replacing ```push``` with ```*```. Your input is welcome.