### PR TITLE
filter releases to consider only the target branch 

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (app) => {
       return
     }
 
-    const { draftRelease, lastRelease } = await findReleases({ app, context })
+    const { draftRelease, lastRelease } = await findReleases({ ref, app, context })
     const {
       commits,
       pullRequests: mergedPullRequests,

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -17,7 +17,7 @@ const sortReleases = (releases) => {
   }
 }
 
-module.exports.findReleases = async ({ app, context }) => {
+module.exports.findReleases = async ({ ref, app, context }) => {
   let releases = await context.github.paginate(
     context.github.repos.listReleases.endpoint.merge(
       context.repo({
@@ -27,9 +27,10 @@ module.exports.findReleases = async ({ app, context }) => {
   )
 
   log({ app, context, message: `Found ${releases.length} releases` })
-
-  const sortedPublishedReleases = sortReleases(releases.filter((r) => !r.draft))
-  const draftRelease = releases.find((r) => r.draft)
+  
+  const filteredReleases = releases.filter((r) => ref.match(`/${r.target_commitish}$`))
+  const sortedPublishedReleases = sortReleases(filteredReleases.filter((r) => !r.draft))
+  const draftRelease = filteredReleases.find((r) => r.draft)
   const lastRelease =
     sortedPublishedReleases[sortedPublishedReleases.length - 1]
 


### PR DESCRIPTION
Consider only releases targeting the same branch as the branch being used for the drafting the new release.
Releases that are for other branches will not be considered for the calculation for the changes.

This also possibly addresses #656