### PR TITLE
Filter releases to consider only the target branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `sort-direction`       | Optional | Sort changelog in ascending or descending order. Can be one of: `ascending`, `descending`. Default: `descending`.                                                          |
 | `prerelease`           | Optional | Mark the draft release as pre-release. Default `false`.                                                                                                                    |
 | `version-resolver`     | Optional | Adjust the `$RESOLVED_VERSION` variable using labels. Refer to [Version Resolver](#version-resolver) to learn more about this                                              |
+| `filter-by-commitish`  | Optional | Filter previous releases to consider only the target branch of the release. Default: `false`.                                                                              |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ module.exports = (app) => {
       return
     }
 
-    const { draftRelease, lastRelease } = await findReleases({ ref, app, context })
+    const { draftRelease, lastRelease } = await findReleases({
+      ref,
+      app,
+      context,
+      config,
+    })
     const {
       commits,
       pullRequests: mergedPullRequests,

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'sort-by': SORT_BY.mergedAt,
   'sort-direction': SORT_DIRECTIONS.descending,
   prerelease: false,
+  'filter-by-commitish': false,
 })
 
 module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -17,7 +17,7 @@ const sortReleases = (releases) => {
   }
 }
 
-module.exports.findReleases = async ({ ref, app, context }) => {
+module.exports.findReleases = async ({ ref, app, context, config }) => {
   let releases = await context.github.paginate(
     context.github.repos.listReleases.endpoint.merge(
       context.repo({
@@ -27,9 +27,14 @@ module.exports.findReleases = async ({ ref, app, context }) => {
   )
 
   log({ app, context, message: `Found ${releases.length} releases` })
-  
-  const filteredReleases = releases.filter((r) => ref.match(`/${r.target_commitish}$`))
-  const sortedPublishedReleases = sortReleases(filteredReleases.filter((r) => !r.draft))
+
+  const { 'filter-by-commitish': filterByCommitish } = config
+  const filteredReleases = filterByCommitish
+    ? releases.filter((r) => ref.match(`/${r.target_commitish}$`))
+    : releases
+  const sortedPublishedReleases = sortReleases(
+    filteredReleases.filter((r) => !r.draft)
+  )
   const draftRelease = filteredReleases.find((r) => r.draft)
   const lastRelease =
     sortedPublishedReleases[sortedPublishedReleases.length - 1]

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -56,6 +56,10 @@ const schema = (context) => {
 
       prerelease: Joi.boolean().default(DEFAULT_CONFIG.prerelease),
 
+      'filter-by-commitish': Joi.boolean().default(
+        DEFAULT_CONFIG['filter-by-commitish']
+      ),
+
       replacers: Joi.array()
         .items(
           Joi.object().keys({

--- a/schema.json
+++ b/schema.json
@@ -87,6 +87,10 @@
       "default": false,
       "type": "boolean"
     },
+    "filter-by-commitish": {
+      "default": false,
+      "type": "boolean"
+    },
     "replacers": {
       "default": [],
       "type": "array",


### PR DESCRIPTION
Filter releases to consider only the target branch, this time by enabling a config option named `filter-by-commitish`.
The default is `false` so previous behaviour is unchanged.

Should fix the breaking changes of #657 