### PR TITLE
Improve example to use default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - $default-branch
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
As all new projects are using main instead of default we make use of github macro in order to have an example that works regardless which is current default branch.

See https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/ for details.