### PR TITLE
Container compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ LABEL "com.github.actions.color"="orange"
 WORKDIR /app
 COPY . .
 RUN yarn --frozen-lockfile
-ENTRYPOINT [ "/app/node_modules/.bin/probot", "receive", "/app/index.js" ]
+ENTRYPOINT [ "/app/node_modules/.bin/probot" ]
+CMD [ "receive", "/app/index.js" ]

--- a/index.js
+++ b/index.js
@@ -86,7 +86,9 @@ module.exports = (app) => {
       })
     }
 
-    setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
+    if (runnerIsActions()) {
+      setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
+    }
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -12,8 +12,14 @@ const log = require('./lib/log')
 const core = require('@actions/core')
 const { runnerIsActions } = require('./lib/utils')
 
-module.exports = (app) => {
+module.exports = (app, { getRouter }) => {
   const event = runnerIsActions() ? '*' : 'push'
+
+  if (!runnerIsActions() && typeof getRouter === 'function') {
+    getRouter().get('/healthz', (req, res) => {
+      res.status(200).json({ status: 'pass' })
+    })
+  }
 
   app.on(event, async (context) => {
     const { shouldDraft, configName, version, tag, name } = getInput()


### PR DESCRIPTION
Github Enterprise doesn't have official Action support yet and the release-drafter needs still to be run in GITHUB_APP mode:

- Fix the Docker entrypoint to actually run without errors
- Avoid creating any Actions output, if we aren't in Actions mode
- Add a healthcheck endpoint for Kubernetes deployments in Github App mode
