### PR TITLE
Add autolabeler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - master
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:
@@ -258,6 +262,29 @@ replacers:
     replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
   - search: 'myname'
     replace: 'My Name'
+```
+
+## Autolabeler
+
+You can add automatically a label into a pull request, with the `autolabeler` option. Available matchers are `files` (glob), `branch` (regex), `title` (regex) and `body` (regex).
+
+```yml
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JIRA-[0-9]{1,4}/'
 ```
 
 ## Projects that don't use Semantic Versioning

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -17,6 +17,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'exclude-labels': [],
   'include-labels': [],
   replacers: [],
+  autolabeler: [],
   'sort-by': SORT_BY.mergedAt,
   'sort-direction': SORT_DIRECTIONS.descending,
   prerelease: false,

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const Joi = require('@hapi/joi')
 const { SORT_BY, SORT_DIRECTIONS } = require('./sort-pull-requests')
 const { DEFAULT_CONFIG } = require('./default-config')
-const { validateReplacers } = require('./template')
+const { validateReplacers, validateAutolabeler } = require('./template')
 
 const schema = (context) => {
   const defaultBranch = _.get(
@@ -75,6 +75,18 @@ const schema = (context) => {
         )
         .default(DEFAULT_CONFIG.replacers),
 
+      autolabeler: Joi.array()
+        .items(
+          Joi.object().keys({
+            label: Joi.string().required(),
+            files: Joi.array().items(Joi.string()).single().default([]),
+            branch: Joi.array().items(Joi.string()).single().default([]),
+            title: Joi.array().items(Joi.string()).single().default([]),
+            body: Joi.array().items(Joi.string()).single().default([]),
+          })
+        )
+        .default(DEFAULT_CONFIG.autolabeler),
+
       categories: Joi.array()
         .items(
           Joi.object()
@@ -138,6 +150,15 @@ const validateSchema = (context, repoConfig) => {
     })
   } catch (error) {
     config.replacers = []
+  }
+
+  try {
+    config.autolabeler = validateAutolabeler({
+      context,
+      autolabeler: config.autolabeler,
+    })
+  } catch (error) {
+    config.autolabeler = []
   }
 
   return config

--- a/lib/template.js
+++ b/lib/template.js
@@ -52,5 +52,33 @@ function validateReplacers({ context, replacers }) {
     .filter(Boolean)
 }
 
+function validateAutolabeler({ context, autolabeler }) {
+  return autolabeler
+    .map((autolabel) => {
+      try {
+        return {
+          ...autolabel,
+          branch: autolabel.branch.map((reg) => {
+            return toRegex(reg)
+          }),
+          title: autolabel.title.map((reg) => {
+            return toRegex(reg)
+          }),
+          body: autolabel.body.map((reg) => {
+            return toRegex(reg)
+          }),
+        }
+      } catch (e) {
+        log({
+          context,
+          message: `Bad autolabeler regex: '${autolabel.branch}', '${autolabel.title}' or '${autolabel.body}'`,
+        })
+        return false
+      }
+    })
+    .filter(Boolean)
+}
+
 module.exports.template = template
 module.exports.validateReplacers = validateReplacers
+module.exports.validateAutolabeler = validateAutolabeler

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cli-table3": "0.6.0",
     "compare-versions": "3.6.0",
     "escape-string-regexp": "4.0.0",
+    "ignore": "5.1.8",
     "lodash": "4.17.20",
     "probot": "11.0.6",
     "regex-parser": "2.2.11",

--- a/schema.json
+++ b/schema.json
@@ -117,6 +117,49 @@
         "required": ["search", "replace"]
       }
     },
+    "autolabeler": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "files": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "branch": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "body": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "patterns": [],
+        "required": ["label"]
+      }
+    },
     "categories": {
       "default": [],
       "type": "array",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,6 +3052,11 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha1-SMptcvbGo68Aqa1K5odr44ieKwk=
 
+ignore@5.1.8:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"


### PR DESCRIPTION
As release-drafter is catogorizing releases notes based on labels, it's nice to integrate optional labeling support as well. Check the README for configuration.
![image](https://user-images.githubusercontent.com/9297850/107543655-15eba100-6bd2-11eb-927a-9ad5980ddc88.png)
![image](https://user-images.githubusercontent.com/9297850/107543703-213ecc80-6bd2-11eb-9060-a300bff356dc.png)
