### PR TITLE
Configurable functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jobs:
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml
+        #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml

--- a/action.yml
+++ b/action.yml
@@ -35,12 +35,22 @@ inputs:
     default: ''
   prerelease:
     description: |
-      A boolean indicating whether the relase being created or updated is a prerelease.
+      A boolean indicating whether the release being created or updated is a prerelease.
     required: false
     default: ''
   commitish:
     description: |
       The object that the release should be created to point to.
+    required: false
+    default: ''
+  disable-releaser:
+    description: |
+      A boolean indicating whether the releaser mode is disabled.
+    required: false
+    default: ''
+  disable-autolabeler:
+    description: |
+      A boolean indicating whether the autolabeler mode is disabled.
     required: false
     default: ''
 outputs:

--- a/index.js
+++ b/index.js
@@ -29,12 +29,14 @@ module.exports = (app, { getRouter }) => {
       'pull_request.synchronize',
     ],
     async (context) => {
+      const { disableAutolabeler } = getInput()
+
       const config = await getConfig({
         context,
         configName: core.getInput('config-name'),
       })
 
-      if (config === null) return
+      if (config === null || disableAutolabeler) return
 
       let issue = {
         ...context.issue({ pull_number: context.payload.pull_request.number }),
@@ -122,7 +124,14 @@ module.exports = (app, { getRouter }) => {
   )
 
   app.on(event, async (context) => {
-    const { shouldDraft, configName, version, tag, name } = getInput()
+    const {
+      shouldDraft,
+      configName,
+      version,
+      tag,
+      name,
+      disableReleaser,
+    } = getInput()
 
     const config = await getConfig({
       context,
@@ -131,7 +140,7 @@ module.exports = (app, { getRouter }) => {
 
     const { isPreRelease } = getInput({ config })
 
-    if (config === null) return
+    if (config === null || disableReleaser) return
 
     // GitHub Actions merge payloads slightly differ, in that their ref points
     // to the PR branch instead of refs/heads/master
@@ -207,6 +216,10 @@ function getInput({ config } = {}) {
       version: core.getInput('version') || undefined,
       tag: core.getInput('tag') || undefined,
       name: core.getInput('name') || undefined,
+      disableReleaser:
+        core.getInput('disable-releaser').toLowerCase() === 'true',
+      disableAutolabeler:
+        core.getInput('disable-autolabeler').toLowerCase() === 'true',
     }
   }
 


### PR DESCRIPTION
The main motivation here is to have some control which events are dispatched to the actual "releaser" code as it gets processed with every event now: configuring the release-drafter for `pull_request` only, makes it generate draft releases as well.

This can now be controlled via action inputs for both "releaser" and "autolabeler" independently and both functionalities are enabled by default.
