### PR TITLE
Add $NEXT_{PATCH,MINOR,MAJOR}_VERSION_{PATCH,MINOR,MAJOR} variables

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -21,8 +21,53 @@ const splitSemVer = (input, versionKey = 'version') => {
 const getTemplatableVersion = (input) => {
   const templatableVersion = {
     $NEXT_MAJOR_VERSION: splitSemVer({ ...input, inc: 'major' }),
+    $NEXT_MAJOR_VERSION_MAJOR: splitSemVer({
+      ...input,
+      inc: 'major',
+      template: '$MAJOR',
+    }),
+    $NEXT_MAJOR_VERSION_MINOR: splitSemVer({
+      ...input,
+      inc: 'major',
+      template: '$MINOR',
+    }),
+    $NEXT_MAJOR_VERSION_PATCH: splitSemVer({
+      ...input,
+      inc: 'major',
+      template: '$PATCH',
+    }),
     $NEXT_MINOR_VERSION: splitSemVer({ ...input, inc: 'minor' }),
+    $NEXT_MINOR_VERSION_MAJOR: splitSemVer({
+      ...input,
+      inc: 'minor',
+      template: '$MAJOR',
+    }),
+    $NEXT_MINOR_VERSION_MINOR: splitSemVer({
+      ...input,
+      inc: 'minor',
+      template: '$MINOR',
+    }),
+    $NEXT_MINOR_VERSION_PATCH: splitSemVer({
+      ...input,
+      inc: 'minor',
+      template: '$PATCH',
+    }),
     $NEXT_PATCH_VERSION: splitSemVer({ ...input, inc: 'patch' }),
+    $NEXT_PATCH_VERSION_MAJOR: splitSemVer({
+      ...input,
+      inc: 'patch',
+      template: '$MAJOR',
+    }),
+    $NEXT_PATCH_VERSION_MINOR: splitSemVer({
+      ...input,
+      inc: 'patch',
+      template: '$MINOR',
+    }),
+    $NEXT_PATCH_VERSION_PATCH: splitSemVer({
+      ...input,
+      inc: 'patch',
+      template: '$PATCH',
+    }),
     $INPUT_VERSION: splitSemVer(input, 'inputVersion'),
     $RESOLVED_VERSION: splitSemVer({
       ...input,

--- a/test/fixtures/config/config-with-major-minor-patch-version-template.yml
+++ b/test/fixtures/config/config-with-major-minor-patch-version-template.yml
@@ -1,4 +1,4 @@
-template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION, minor=$NEXT_MINOR_VERSION, patch=$NEXT_PATCH_VERSION
+template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION (major=$NEXT_MAJOR_VERSION_MAJOR, minor=$NEXT_MAJOR_VERSION_MINOR, patch=$NEXT_MAJOR_VERSION_PATCH), minor=$NEXT_MINOR_VERSION (major=$NEXT_MINOR_VERSION_MAJOR, minor=$NEXT_MINOR_VERSION_MINOR, patch=$NEXT_MINOR_VERSION_PATCH), patch=$NEXT_PATCH_VERSION (major=$NEXT_PATCH_VERSION_MAJOR, minor=$NEXT_PATCH_VERSION_MINOR, patch=$NEXT_PATCH_VERSION_PATCH)
 name-template: 'v$NEXT_PATCH_VERSION (Code name: Placeholder)'
 tag-template: v$NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR.$PATCH

--- a/test/fixtures/config/config-with-major-minor-version-template.yml
+++ b/test/fixtures/config/config-with-major-minor-version-template.yml
@@ -1,4 +1,4 @@
-template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION, minor=$NEXT_MINOR_VERSION, patch=$NEXT_PATCH_VERSION
+template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION (major=$NEXT_MAJOR_VERSION_MAJOR, minor=$NEXT_MAJOR_VERSION_MINOR, patch=$NEXT_MAJOR_VERSION_PATCH), minor=$NEXT_MINOR_VERSION (major=$NEXT_MINOR_VERSION_MAJOR, minor=$NEXT_MINOR_VERSION_MINOR, patch=$NEXT_MINOR_VERSION_PATCH), patch=$NEXT_PATCH_VERSION (major=$NEXT_PATCH_VERSION_MAJOR, minor=$NEXT_PATCH_VERSION_MINOR, patch=$NEXT_PATCH_VERSION_PATCH)
 name-template: 'v$NEXT_MINOR_VERSION (Code name: Placeholder)'
 tag-template: v$NEXT_MINOR_VERSION
 version-template: $MAJOR.$MINOR

--- a/test/fixtures/config/config-with-major-version-template.yml
+++ b/test/fixtures/config/config-with-major-version-template.yml
@@ -1,4 +1,4 @@
-template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION, minor=$NEXT_MINOR_VERSION, patch=$NEXT_PATCH_VERSION
+template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION (major=$NEXT_MAJOR_VERSION_MAJOR, minor=$NEXT_MAJOR_VERSION_MINOR, patch=$NEXT_MAJOR_VERSION_PATCH), minor=$NEXT_MINOR_VERSION (major=$NEXT_MINOR_VERSION_MAJOR, minor=$NEXT_MINOR_VERSION_MINOR, patch=$NEXT_MINOR_VERSION_PATCH), patch=$NEXT_PATCH_VERSION (major=$NEXT_PATCH_VERSION_MAJOR, minor=$NEXT_PATCH_VERSION_MINOR, patch=$NEXT_PATCH_VERSION_PATCH)
 name-template: 'v$NEXT_MAJOR_VERSION (Code name: Placeholder)'
 tag-template: v$NEXT_MAJOR_VERSION
 version-template: $MAJOR

--- a/test/fixtures/config/config-with-next-versioning.yml
+++ b/test/fixtures/config/config-with-next-versioning.yml
@@ -1,3 +1,3 @@
-template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION, minor=$NEXT_MINOR_VERSION, patch=$NEXT_PATCH_VERSION
+template: Placeholder with example. Automatically calculated values are next major=$NEXT_MAJOR_VERSION (major=$NEXT_MAJOR_VERSION_MAJOR, minor=$NEXT_MAJOR_VERSION_MINOR, patch=$NEXT_MAJOR_VERSION_PATCH), minor=$NEXT_MINOR_VERSION (major=$NEXT_MINOR_VERSION_MAJOR, minor=$NEXT_MINOR_VERSION_MINOR, patch=$NEXT_MINOR_VERSION_PATCH), patch=$NEXT_PATCH_VERSION (major=$NEXT_PATCH_VERSION_MAJOR, minor=$NEXT_PATCH_VERSION_MINOR, patch=$NEXT_PATCH_VERSION_PATCH)
 name-template: 'v$NEXT_PATCH_VERSION (Code name: Placeholder)'
 tag-template: v$NEXT_PATCH_VERSION

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -429,7 +429,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.1.0, patch=2.0.1",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)",
                   "draft": true,
                   "name": "v2.0.1 (Code name: Placeholder)",
                   "prerelease": false,
@@ -1170,7 +1170,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0, minor=2.1.0, patch=2.0.1",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)",
                   "draft": true,
                   "name": "v2.0.1 (Code name: Placeholder)",
                   "prerelease": false,
@@ -1214,7 +1214,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0, minor=2.1, patch=2.0",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)",
                   "draft": true,
                   "name": "v2.1 (Code name: Placeholder)",
                   "prerelease": false,
@@ -1258,7 +1258,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3, minor=2, patch=2",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)",
                   "draft": true,
                   "name": "v3 (Code name: Placeholder)",
                   "prerelease": false,

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -3,47 +3,167 @@ const each = require('jest-each').default
 
 describe('versions', () => {
   it('extracts a version-like string from the last tag', () => {
-    const versionInfo = getVersionInfo({
-      tag_name: 'v10.0.3',
-      name: 'Some release',
-    })
+    const versionInfo = getVersionInfo(
+      {
+        tag_name: 'v10.0.3',
+        name: 'Some release',
+      },
+      '$MAJOR.$MINOR.$PATCH'
+    )
 
     expect(versionInfo.$NEXT_MAJOR_VERSION.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_MINOR_VERSION.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.template).toEqual('$PATCH')
   })
 
   it('extracts a version-like string from the last release name if the tag isnt a version', () => {
-    const versionInfo = getVersionInfo({
-      tag_name: 'notaproperversion',
-      name: '10.0.3',
-    })
+    const versionInfo = getVersionInfo(
+      {
+        tag_name: 'notaproperversion',
+        name: '10.0.3',
+      },
+      '$MAJOR.$MINOR.$PATCH'
+    )
 
     expect(versionInfo.$NEXT_MAJOR_VERSION.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_MINOR_VERSION.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.template).toEqual('$PATCH')
   })
 
   it('preferences tags over release names', () => {
-    const versionInfo = getVersionInfo({
-      tag_name: '10.0.3',
-      name: '8.1.0',
-    })
+    const versionInfo = getVersionInfo(
+      {
+        tag_name: '10.0.3',
+        name: '8.1.0',
+      },
+      '$MAJOR.$MINOR.$PATCH'
+    )
 
     expect(versionInfo.$NEXT_MAJOR_VERSION.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_MINOR_VERSION.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.template).toEqual('$PATCH')
   })
 
   it('handles alpha/beta releases', () => {
-    const versionInfo = getVersionInfo({
-      tag_name: 'v10.0.3-alpha',
-      name: 'Some release',
-    })
+    const versionInfo = getVersionInfo(
+      {
+        tag_name: 'v10.0.3-alpha',
+        name: 'Some release',
+      },
+      '$MAJOR.$MINOR.$PATCH'
+    )
 
     expect(versionInfo.$NEXT_MAJOR_VERSION.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.version).toEqual('11.0.0')
+    expect(versionInfo.$NEXT_MAJOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_MINOR_VERSION.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.version).toEqual('10.1.0')
+    expect(versionInfo.$NEXT_MINOR_VERSION_PATCH.template).toEqual('$PATCH')
     expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION.template).toEqual(
+      '$MAJOR.$MINOR.$PATCH'
+    )
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MAJOR.template).toEqual('$MAJOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_MINOR.template).toEqual('$MINOR')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION_PATCH.template).toEqual('$PATCH')
   })
 
   it('returns undefined if no version was found in tag or name', () => {


### PR DESCRIPTION
In our use case just having the full version string available in the template isn't enough.
E.g. `$NEXT_MINOR_VERSION` will render the full e.g. `2.8.0`, but want to render headings that just contain "2.8" (Like "What's new in Play 2.8?", but more importantly we have links to our docs that look like
- https://www.playframework.com/documentation/2.8.x/Home
- https://www.playframework.com/documentation/2.8.x/Migration28

So we need to be able to render versions like "2.8.x" or just "28".
With this PR we can do this via: "`$NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR.x`" and "`$NEXT_MINOR_VERSION_MAJOR$NEXT_MINOR_VERSION_MINOR`"