### PR TITLE
Use commitish from action inputs. Fixes #824.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ module.exports = (app, { getRouter }) => {
       tag,
       name,
       disableReleaser,
+      commitish,
     } = getInput()
 
     const config = await getConfig({
@@ -181,6 +182,7 @@ module.exports = (app, { getRouter }) => {
       name,
       isPreRelease,
       shouldDraft,
+      commitish,
     })
 
     let createOrUpdateReleaseResponse
@@ -220,6 +222,7 @@ function getInput({ config } = {}) {
         core.getInput('disable-releaser').toLowerCase() === 'true',
       disableAutolabeler:
         core.getInput('disable-autolabeler').toLowerCase() === 'true',
+      commitish: core.getInput('commitish') || undefined,
     }
   }
 

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -251,6 +251,7 @@ module.exports.generateReleaseInfo = ({
   name = undefined,
   isPreRelease,
   shouldDraft,
+  commitish = undefined,
 }) => {
   let body = config.template
 
@@ -290,7 +291,9 @@ module.exports.generateReleaseInfo = ({
       : ''
   }
 
-  let commitish = config['commitish'] || ''
+  if (commitish === undefined) {
+    commitish = config['commitish'] || ''
+  }
 
   return {
     name,


### PR DESCRIPTION
The commitish parameter was previously ignored from action inputs and only read from the static config.yml, when the Readme and action.yml advertised the parameter as action inputs.

Fix by @MariuszKogut

Fixes #824