### PR TITLE
Fix prerelease string getting removed and add $COMPLETE version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ You can use any of the following variables in your `template`, `name-template` a
 
 You can use any of the following variables in `version-template` to format the `$NEXT_{PATCH,MINOR,MAJOR}_VERSION` variables:
 
-| Variable | Description               |
-| -------- | ------------------------- |
-| `$PATCH` | The patch version number. |
-| `$MINOR` | The minor version number. |
-| `$MAJOR` | The major version number. |
+| Variable    | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `$PATCH`    | The patch version number.                                    |
+| `$MINOR`    | The minor version number.                                    |
+| `$MAJOR`    | The major version number.                                    |
+| `$COMPLETE` | The complete version string (including any prerelease info). |
 
 ## Version Resolver
 

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -18,6 +18,7 @@ const splitSemVer = (input, versionKey = 'version') => {
     $MAJOR: semver.major(version),
     $MINOR: semver.minor(version),
     $PATCH: semver.patch(version),
+    $COMPLETE: version,
   }
 }
 

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -5,12 +5,9 @@ const splitSemVer = (input, versionKey = 'version') => {
     return null
   }
 
-  let version
-  if (input.inc) {
-    version = semver.inc(input[versionKey], input.inc, true)
-  } else {
-    version = input[versionKey].version
-  }
+  const version = input.inc
+    ? semver.inc(input[versionKey], input.inc, true)
+    : input[versionKey].version
 
   return {
     ...input,

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -5,9 +5,16 @@ const splitSemVer = (input, versionKey = 'version') => {
     return null
   }
 
-  const version = input.inc
-    ? semver.inc(input[versionKey], input.inc, true)
-    : semver.parse(input[versionKey])
+  let version
+  if (input.inc) {
+    version = semver.inc(input[versionKey], input.inc, true)
+  } else {
+    const semverVersion = semver.parse(input[versionKey])
+    if (!semverVersion) {
+      return null
+    }
+    version = semverVersion.version
+  }
 
   return {
     ...input,
@@ -36,14 +43,24 @@ const getTemplatableVersion = (input) => {
   return templatableVersion
 }
 
+const toSemver = (version) => {
+  const result = semver.parse(version)
+  if (result) {
+    return result
+  }
+
+  // doesn't handle prerelease
+  return semver.coerce(version)
+}
+
 const coerceVersion = (input) => {
   if (!input) {
     return null
   }
 
   return typeof input === 'object'
-    ? semver.coerce(input.tag_name) || semver.coerce(input.name)
-    : semver.coerce(input)
+    ? toSemver(input.tag_name) || toSemver(input.name)
+    : toSemver(input)
 }
 
 module.exports.getVersionInfo = (

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -9,11 +9,7 @@ const splitSemVer = (input, versionKey = 'version') => {
   if (input.inc) {
     version = semver.inc(input[versionKey], input.inc, true)
   } else {
-    const semverVersion = semver.parse(input[versionKey])
-    if (!semverVersion) {
-      return null
-    }
-    version = semverVersion.version
+    version = input[versionKey].version
   }
 
   return {

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -36,14 +36,20 @@ describe('versions', () => {
   })
 
   it('handles alpha/beta releases', () => {
-    const versionInfo = getVersionInfo({
-      tag_name: 'v10.0.3-alpha',
-      name: 'Some release',
-    })
+    const versionInfo = getVersionInfo(
+      {
+        tag_name: 'v10.0.3-alpha',
+        name: 'Some release',
+      },
+      null,
+      'v10.0.3-alpha'
+    )
 
     expect(versionInfo.$NEXT_MAJOR_VERSION.version).toEqual('11.0.0')
     expect(versionInfo.$NEXT_MINOR_VERSION.version).toEqual('10.1.0')
-    expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.4')
+    expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('10.0.3')
+    expect(versionInfo.$INPUT_VERSION.version).toEqual('10.0.3-alpha')
+    expect(versionInfo.$RESOLVED_VERSION.version).toEqual('10.0.3-alpha')
   })
 
   it('returns undefined if no version was found in tag or name', () => {


### PR DESCRIPTION
Currently if the version is a prerelease the prerelease string is discarded because `semver.coerce` discards it.

With this PR we now use `semver.parse` instead and fall back to coerce.

It also updates `splitSemVer` to always return a string instead of sometimes a `SemVer` instance (which currently becomes a string in `template` due to it having a `toString`) and sometimes string.

Finally it adds a `$COMPELTE` variable that can be used to access the full version string, otherwise it's still not possible to get the prerelease info in the template.