### PR TITLE
Include `edited` event for autolabeler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository
-1. Configure and install the dependencies: `npm install`
+1. Configure and install the dependencies: `yarn install`
 1. Make sure the tests pass on your machine: `npm test`, note: these tests also apply the linter, so no need to lint seperately
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Make your change, add tests, and make sure the tests still pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,15 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 1. [Fork][fork] and clone the repository
 1. Configure and install the dependencies: `yarn install`
-1. Make sure the tests pass on your machine: `npm test`, note: these tests also apply the linter, so no need to lint seperately
+1. Make sure the tests pass on your machine: `yarn test`, note: these tests also apply the linter, so no need to lint seperately
 1. Create a new branch: `git checkout -b my-branch-name`
-1. Make your change, add tests, and make sure the tests still pass
+1. Make your change, add tests, build with `yarn prettier && yarn lint --fix && yarn build` and make sure the tests still pass
 1. Push to your fork and [submit a pull request][pr]
 1. Give yourself a high five, and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `npm test`
+- Follow the [style guide][style] which is using standard. Any linting errors should be shown when running `yarn test`
 - Write and update tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = (app, { getRouter }) => {
       'pull_request.opened',
       'pull_request.reopened',
       'pull_request.synchronize',
+      'pull_request.edited',
     ],
     async (context) => {
       const { disableAutolabeler } = getInput()


### PR DESCRIPTION
# Why

One of the input for the autolabeler is the PR title. If while creating the PR, the title didn't conform with any of the autolabeling rules, changing afterwards does not trigger the autolabeler. 

# Summary of changes

- Include the `edited` event of pull requests.