### PR TITLE
Mod error message when invalid config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,8 +24,12 @@ module.exports.getConfig = async function getConfig({ context, configName }) {
       log({
         context,
         message:
-          'Config validation errors, please fix the following issues in release-drafter.yml:\n' +
-          joiValidationErrorsAsTable(error),
+          'Config validation errors, please fix the following issues in ' +
+          (configName || DEFAULT_CONFIG_NAME) +
+          ':\n' +
+          joiValidationErrorsAsTable(error) +
+          '\nNote: This message will also be output if the configuration file is not found. ' +
+          'And the configuration file must reside in your default branch.',
       })
     }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,5 @@
 const core = require('@actions/core')
 const { validateSchema } = require('./schema')
-const { DEFAULT_CONFIG } = require('./default-config')
 const log = require('./log')
 const { runnerIsActions } = require('./utils')
 const Table = require('cli-table3')
@@ -11,8 +10,16 @@ module.exports.getConfig = async function getConfig({ context, configName }) {
   try {
     const repoConfig = await context.config(
       configName || DEFAULT_CONFIG_NAME,
-      DEFAULT_CONFIG
+      null
     )
+    if (repoConfig == null) {
+      // noinspection ExceptionCaughtLocallyJS
+      throw new Error(
+        'Configuration file .github/' +
+          (configName || DEFAULT_CONFIG_NAME) +
+          ' is not found. The configuration file must reside in your default branch.'
+      )
+    }
 
     const config = validateSchema(context, repoConfig)
 
@@ -27,9 +34,7 @@ module.exports.getConfig = async function getConfig({ context, configName }) {
           'Config validation errors, please fix the following issues in ' +
           (configName || DEFAULT_CONFIG_NAME) +
           ':\n' +
-          joiValidationErrorsAsTable(error) +
-          '\nNote: This message will also be output if the configuration file is not found. ' +
-          'And the configuration file must reside in your default branch.',
+          joiValidationErrorsAsTable(error),
       })
     }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -28,6 +28,34 @@ describe('getConfig', () => {
     })
   })
 
+  it('config file does not exist', async () => {
+    let warnMessage
+    let warnStack
+    const context = {
+      payload: { repository: { default_branch: 'master' } },
+      config: null,
+      log: {
+        info: jest.fn(),
+        warn: jest.fn((e, m) => {
+          warnMessage = m
+          warnStack = e.stack
+        }),
+      },
+    }
+
+    const config = await getConfig({
+      context,
+    })
+
+    expect(config).toBeNull()
+    expect(warnMessage).toContain('Invalid config file')
+    expect(warnStack).toContain(
+      'context.config is not a function'
+      // In the test, this message is set by Probot. Actually the message below:
+      // 'Configuration file .github/release-drafter.yml is not found. The configuration file must reside in your default branch.'
+    )
+  })
+
   describe('`replacers` option', () => {
     it('validates `replacers` option', async () => {
       let infoMessage

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -30,19 +30,28 @@ describe('getConfig', () => {
 
   describe('`replacers` option', () => {
     it('validates `replacers` option', async () => {
+      let infoMessage
+      let warnMessage
       const context = {
         payload: { repository: { default_branch: 'master' } },
         config: createGetConfigMock({ replacers: 'bogus' }),
-        log: { info: jest.fn(), warn: jest.fn() },
+        log: {
+          info: jest.fn((m) => {
+            infoMessage = m
+          }),
+          warn: jest.fn((_, m) => {
+            warnMessage = m
+          }),
+        },
       }
 
-      await expect(
-        getConfig({
-          context,
-        })
-      ).rejects.toThrow(
-        'child "replacers" fails because ["replacers" must be an array]'
-      )
+      const config = await getConfig({
+        context,
+      })
+
+      expect(config).toBeNull()
+      expect(warnMessage).toContain('Invalid config file')
+      expect(infoMessage).toContain('"replacers" must be an array')
     })
 
     it('accepts valid `replacers`', async () => {
@@ -67,17 +76,28 @@ describe('getConfig', () => {
 
   describe('`sort-direction` option', () => {
     it('validates `sort-direction` option', async () => {
+      let infoMessage
+      let warnMessage
       const context = {
         payload: { repository: { default_branch: 'master' } },
         config: createGetConfigMock({ 'sort-direction': 'bogus' }),
-        log: { info: jest.fn(), warn: jest.fn() },
+        log: {
+          info: jest.fn((m) => {
+            infoMessage = m
+          }),
+          warn: jest.fn((_, m) => {
+            warnMessage = m
+          }),
+        },
       }
 
-      await expect(
-        getConfig({
-          context,
-        })
-      ).rejects.toThrow(
+      const config = await getConfig({
+        context,
+      })
+
+      expect(config).toBeNull()
+      expect(warnMessage).toContain('Invalid config file')
+      expect(infoMessage).toContain(
         '"sort-direction" must be one of [ascending, descending]'
       )
     })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -36,7 +36,7 @@ describe('getConfig', () => {
         log: { info: jest.fn(), warn: jest.fn() },
       }
 
-      expect(
+      await expect(
         getConfig({
           context,
         })
@@ -73,7 +73,7 @@ describe('getConfig', () => {
         log: { info: jest.fn(), warn: jest.fn() },
       }
 
-      expect(
+      await expect(
         getConfig({
           context,
         })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -29,57 +29,50 @@ describe('getConfig', () => {
   })
 
   it('config file does not exist', async () => {
-    let warnMessage
-    let warnStack
     const context = {
       payload: { repository: { default_branch: 'master' } },
       config: null,
-      log: {
-        info: jest.fn(),
-        warn: jest.fn((e, m) => {
-          warnMessage = m
-          warnStack = e.stack
-        }),
-      },
+      log: { info: jest.fn(), warn: jest.fn() },
     }
+    const warnSpy = jest.spyOn(context.log, 'warn')
 
     const config = await getConfig({
       context,
     })
 
     expect(config).toBeNull()
-    expect(warnMessage).toContain('Invalid config file')
-    expect(warnStack).toContain(
-      'context.config is not a function'
-      // In the test, this message is set by Probot. Actually the message below:
-      // 'Configuration file .github/release-drafter.yml is not found. The configuration file must reside in your default branch.'
+    expect(warnSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stack: expect.stringMatching(/context.config is not a function/),
+        // In the test, this message is set by Probot. Actually the message below:
+        // 'Configuration file .github/release-drafter.yml is not found. The configuration file must reside in your default branch.'
+      }),
+      expect.stringMatching(/Invalid config file/)
     )
   })
 
   describe('`replacers` option', () => {
     it('validates `replacers` option', async () => {
-      let infoMessage
-      let warnMessage
       const context = {
         payload: { repository: { default_branch: 'master' } },
         config: createGetConfigMock({ replacers: 'bogus' }),
-        log: {
-          info: jest.fn((m) => {
-            infoMessage = m
-          }),
-          warn: jest.fn((_, m) => {
-            warnMessage = m
-          }),
-        },
+        log: { info: jest.fn(), warn: jest.fn() },
       }
+      const warnSpy = jest.spyOn(context.log, 'warn')
+      const infoSpy = jest.spyOn(context.log, 'info')
 
       const config = await getConfig({
         context,
       })
 
       expect(config).toBeNull()
-      expect(warnMessage).toContain('Invalid config file')
-      expect(infoMessage).toContain('"replacers" must be an array')
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({}),
+        expect.stringMatching(/Invalid config file/)
+      )
+      expect(infoSpy).toHaveBeenLastCalledWith(
+        expect.stringMatching(/"replacers" must be an array/)
+      )
     })
 
     it('accepts valid `replacers`', async () => {
@@ -104,29 +97,27 @@ describe('getConfig', () => {
 
   describe('`sort-direction` option', () => {
     it('validates `sort-direction` option', async () => {
-      let infoMessage
-      let warnMessage
       const context = {
         payload: { repository: { default_branch: 'master' } },
         config: createGetConfigMock({ 'sort-direction': 'bogus' }),
-        log: {
-          info: jest.fn((m) => {
-            infoMessage = m
-          }),
-          warn: jest.fn((_, m) => {
-            warnMessage = m
-          }),
-        },
+        log: { info: jest.fn(), warn: jest.fn() },
       }
+      const warnSpy = jest.spyOn(context.log, 'warn')
+      const infoSpy = jest.spyOn(context.log, 'info')
 
       const config = await getConfig({
         context,
       })
 
       expect(config).toBeNull()
-      expect(warnMessage).toContain('Invalid config file')
-      expect(infoMessage).toContain(
-        '"sort-direction" must be one of [ascending, descending]'
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({}),
+        expect.stringMatching(/Invalid config file/)
+      )
+      expect(infoSpy).toHaveBeenLastCalledWith(
+        expect.stringMatching(
+          /"sort-direction" must be one of \[ascending, descending\]/
+        )
       )
     })
 


### PR DESCRIPTION
Added the following messages to the error when an invalid configuration file:

1. This message will also be output if the configuration file is not found
2. configuration file must reside in your default branch

~~I wanted to add a message for when a config file was not found, but it was difficult due to its structure, so I decided not to.~~ fixed

~~Two failure tests in  config.test.js, but that is unrelated to this fix.~~ fixed