### PR TITLE
Allow user to optionally set github URL

### DIFF
--- a/bin/generate-fixtures.js
+++ b/bin/generate-fixtures.js
@@ -6,7 +6,8 @@ const fetch = require('node-fetch')
 const { findCommitsWithAssociatedPullRequestsQuery } = require('../lib/commits')
 
 const REPO_NAME = 'release-drafter-test-repo'
-const GITHUB_GRAPHQL_API_ENDPOINT = 'https://api.github.com/graphql'
+const GITHUB_BASE_URL = process.env.GITHUB_BASE_URL || 'https://api.github.com'
+const GITHUB_GRAPHQL_API_ENDPOINT = GITHUB_BASE_URL + '/graphql'
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 
 if (!GITHUB_TOKEN) {


### PR DESCRIPTION
The goal of this PR is to allow the user to provide a base url so that release-drafter can execute a GET request from https://api.github.<ORG_NAME>.com.  Currently the url is hardcoded in the format 'https://api.github.com' and release-drafter is not able to reach repos hosted with an organization in the url.  