### PR TITLE
Add tag-prefix config option

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,6 +3,7 @@ const { SORT_BY, SORT_DIRECTIONS } = require('./sort-pull-requests')
 const DEFAULT_CONFIG = Object.freeze({
   'name-template': '',
   'tag-template': '',
+  'tag-prefix': '',
   'change-template': `* $TITLE (#$NUMBER) @$AUTHOR`,
   'change-title-escapes': '',
   'no-changes-template': `* No changes`,

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -28,10 +28,17 @@ module.exports.findReleases = async ({ ref, context, config }) => {
 
   log({ context, message: `Found ${releases.length} releases` })
 
-  const { 'filter-by-commitish': filterByCommitish } = config
-  const filteredReleases = filterByCommitish
-    ? releases.filter((r) => ref.match(`/${r.target_commitish}$`))
-    : releases
+  const {
+    'filter-by-commitish': filterByCommitish,
+    'tag-prefix': tagPrefix,
+  } = config
+  const filteredReleases = releases
+    .filter((r) =>
+      filterByCommitish ? ref.match(`/${r.target_commitish}$`) : r
+    )
+    .filter((r) =>
+      tagPrefix && tagPrefix.length > 0 ? r.tag_name.startsWith(tagPrefix) : r
+    )
   const sortedPublishedReleases = sortReleases(
     filteredReleases.filter((r) => !r.draft)
   )
@@ -294,7 +301,12 @@ module.exports.generateReleaseInfo = ({
   }
 
   if (tag === undefined) {
-    tag = versionInfo ? template(config['tag-template'] || '', versionInfo) : ''
+    const partialTag = versionInfo
+      ? template(config['tag-template'] || '', versionInfo)
+      : ''
+    tag = config['tag-prefix']
+      ? `${config['tag-prefix']}${partialTag}`
+      : partialTag
   }
 
   if (name === undefined) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -38,6 +38,10 @@ const schema = (context) => {
         .allow('')
         .default(DEFAULT_CONFIG['tag-template']),
 
+      'tag-prefix': Joi.string()
+        .allow('')
+        .default(DEFAULT_CONFIG['tag-prefix']),
+
       'exclude-labels': Joi.array()
         .items(Joi.string())
         .default(DEFAULT_CONFIG['exclude-labels']),

--- a/schema.json
+++ b/schema.json
@@ -59,6 +59,18 @@
         }
       ]
     },
+    "tag-prefix": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [""]
+        },
+        {
+          "default": "",
+          "type": "string"
+        }
+      ]
+    },
     "exclude-labels": {
       "default": [],
       "type": "array",


### PR DESCRIPTION
This config option makes it possible to filter previous releases by git tag name prefix, thus makes it possible to identify tags for a single component in a monorepo.