### PR TITLE
Update `target_commitish` when updating a release

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -350,6 +350,7 @@ const updateRelease = ({ context, draftRelease, releaseInfo }) => {
   const updateReleaseParameters = updateDraftReleaseParameters({
     name: releaseInfo.name || draftRelease.name,
     tag_name: releaseInfo.tag || draftRelease.tag_name,
+    target_commitish: releaseInfo.commitish,
   })
 
   return context.octokit.repos.updateRelease(
@@ -372,6 +373,12 @@ function updateDraftReleaseParameters(parameters) {
   }
   if (!updateReleaseParameters.tag_name) {
     delete updateReleaseParameters.tag_name
+  }
+
+  // Keep existing `target_commitish` if not overriden
+  // (sending `null` resets it to the default branch)
+  if (!updateReleaseParameters.target_commitish) {
+    delete updateReleaseParameters.target_commitish
   }
 
   return updateReleaseParameters


### PR DESCRIPTION
Following https://github.com/release-drafter/release-drafter/pull/865#issuecomment-899041540 - indeed the existing release doesn't get updated, so this PR fixes that.