### PR TITLE
Only consider commits before `commitish`, if provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ module.exports = (app, { getRouter }) => {
       await findCommitsWithAssociatedPullRequests({
         context,
         ref,
+        up_to_commitish: commitish,
         lastRelease,
         config,
       })

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -68,6 +68,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
 const findCommitsWithAssociatedPullRequests = async ({
   context,
   ref,
+  up_to_commitish,
   lastRelease,
   config,
 }) => {
@@ -84,17 +85,35 @@ const findCommitsWithAssociatedPullRequests = async ({
   const dataPath = ['repository', 'object', 'history']
   const repoNameWithOwner = `${owner}/${repo}`
 
+  log({ context, message: `Fetching commits for reference ${ref}` })
+
+  // Resolving commitish to a commit sha so that we can use it as a GraphQL cursor
+  let up_to_commit
+  if (up_to_commitish) {
+    let resolved_commitish = await context.octokit.repos.getCommit({
+      owner,
+      repo,
+      ref: up_to_commitish,
+    })
+    up_to_commit = resolved_commitish.data.sha
+    log({ context, message: `Including commits up to ${up_to_commit}` })
+  }
+
   let data, commits
   if (lastRelease) {
     log({
       context,
-      message: `Fetching all commits for reference ${ref} since ${lastRelease.created_at}`,
+      message: `Including commits since ${lastRelease.created_at}`,
     })
 
     data = await paginate(
       context.octokit.graphql,
       findCommitsWithAssociatedPullRequestsQuery,
-      { ...variables, since: lastRelease.created_at },
+      {
+        ...variables,
+        since: lastRelease.created_at,
+        after: up_to_commit && `${up_to_commit} 0`,
+      },
       dataPath
     )
     // GraphQL call is inclusive of commits from the specified dates.  This means the final
@@ -103,12 +122,13 @@ const findCommitsWithAssociatedPullRequests = async ({
       (commit) => commit.committedDate != lastRelease.created_at
     )
   } else {
-    log({ context, message: `Fetching all commits for reference ${ref}` })
-
     data = await paginate(
       context.octokit.graphql,
       findCommitsWithAssociatedPullRequestsQuery,
-      variables,
+      {
+        ...variables,
+        after: up_to_commit && `${up_to_commit} 0`,
+      },
       dataPath
     )
     commits = _.get(data, [...dataPath, 'nodes'])


### PR DESCRIPTION
Resolves #1053 

When searching for commits to be included in the release notes, if `commitish` is supplied, it is first resolved to a commit sha. That commit sha is then used a starting point for the graphql query. This allows us to generalize the process and support both "static" (commits, tags) and "dynamic" (branches) `commitish` values.
This does not affect `target_commitish` of the release, which will always be the value provided, with no modifications.

Demo repository is here:
https://github.com/mikeroll/release-drafter-1053/releases
https://github.com/mikeroll/release-drafter-1053/actions
Each of the 4 actions correspond to release-drafter configured differently. Added @jetersen to contributors if you want to play around, any of those actions may be restarted to see the different behaviours.
`no-commitish` - uses the repository's default branch, as before. The action is for an old commit, but even if re-run it will include all the later commits in the release, as before.
`commitish-as-branch` - same as above, with the branch specified explicitly.
`commitish-as-sha{,-2}` - the sha of the commit being built (`${{ github.sha }}`) is set as the release target (already worked before) and only the commits up to and including this one are included in the release notes, i.e. the build for commit 3 does not add commit 4.