### PR TITLE
Ensure support new default branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
+      - main
       - master
+
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well


### PR DESCRIPTION
Because terminology change it confuse why not working on new repositories.
Old one for backward compatibility.
https://stevenmortimer.com/5-steps-to-change-github-default-branch-from-master-to-main/