### PR TITLE
Cap evaluated release limit at 1000

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -17,17 +17,28 @@ const sortReleases = (releases) => {
   }
 }
 
+// GitHub API currently returns a 500 HTTP response if you attempt to fetch over 1000 releases.
+const RELEASE_COUNT_LIMIT = 1000
+
 const findReleases = async ({
   context,
   targetCommitish,
   filterByCommitish,
 }) => {
+  let releaseCount = 0
   let releases = await context.octokit.paginate(
     context.octokit.repos.listReleases.endpoint.merge(
       context.repo({
         per_page: 100,
       })
-    )
+    ),
+    (response, done) => {
+      releaseCount += response.data.length
+      if (releaseCount >= RELEASE_COUNT_LIMIT) {
+        done()
+      }
+      return response.data
+    }
   )
 
   log({ context, message: `Found ${releases.length} releases` })


### PR DESCRIPTION
GitHub API currently returns a 500 HTTP response if you attempt to fetch over 1000 releases.

This addresses the issue outlined at https://github.com/release-drafter/release-drafter/issues/1082

fixes #1082