### PR TITLE
Tag prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `category-template`        | Optional | The template to use for each category. Use [category template variables](#category-template-variables) to insert values. Default: `"## $TITLE"`.                                   |
 | `name-template`            | Optional | The template for the name of the draft release. For example: `"v$NEXT_PATCH_VERSION"`.                                                                                             |
 | `tag-template`             | Optional | The template for the tag of the draft release. For example: `"v$NEXT_PATCH_VERSION"`.                                                                                              |
+| `tag-prefix`               | Optional | A known prefix used to filter release tags. For matching tags, this prefix is stripped before attempting to parse the version. Default: `""`                                       |
 | `version-template`         | Optional | The template to use when calculating the next version number for the release. Useful for projects that don't use semantic versioning. Default: `"$MAJOR.$MINOR.$PATCH"`            |
 | `change-template`          | Optional | The template to use for each merged pull request. Use [change template variables](#change-template-variables) to insert values. Default: `"* $TITLE (#$NUMBER) @$AUTHOR"`.         |
 | `change-title-escapes`     | Optional | Characters to escape in `$TITLE` when inserting into `change-template` so that they are not interpreted as Markdown format characters. Default: `""`                               |
@@ -131,6 +132,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `version-resolver`         | Optional | Adjust the `$RESOLVED_VERSION` variable using labels. Refer to [Version Resolver](#version-resolver) to learn more about this                                                      |
 | `commitish`                | Optional | The release target, i.e. branch or commit it should point to. Default: the ref that release-drafter runs for, e.g. `refs/heads/master` if configured to run on pushes to `master`. |
 | `filter-by-commitish`      | Optional | Filter previous releases to consider only those with the target matching `commitish`. Default: `false`.                                                                            |
+| `include-paths`            | Optional | Restrict pull requests included in the release notes to only the pull requests that modified any of the paths in this array. Supports files and directories. Default: `[]`         |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 

--- a/index.js
+++ b/index.js
@@ -159,12 +159,16 @@ module.exports = (app, { getRouter }) => {
     }
 
     const targetCommitish = commitish || config['commitish'] || ref
-    const filterByCommitish = config['filter-by-commitish']
+    const {
+      'filter-by-commitish': filterByCommitish,
+      'tag-prefix': tagPrefix,
+    } = config
 
     const { draftRelease, lastRelease } = await findReleases({
       context,
       targetCommitish,
       filterByCommitish,
+      tagPrefix,
     })
 
     const { commits, pullRequests: mergedPullRequests } =

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,6 +3,7 @@ const { SORT_BY, SORT_DIRECTIONS } = require('./sort-pull-requests')
 const DEFAULT_CONFIG = Object.freeze({
   'name-template': '',
   'tag-template': '',
+  'tag-prefix': '',
   'change-template': `* $TITLE (#$NUMBER) @$AUTHOR`,
   'change-title-escapes': '',
   'no-changes-template': `* No changes`,

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -24,6 +24,7 @@ const findReleases = async ({
   context,
   targetCommitish,
   filterByCommitish,
+  tagPrefix,
 }) => {
   let releaseCount = 0
   let releases = await context.octokit.paginate(
@@ -46,12 +47,15 @@ const findReleases = async ({
   // `refs/heads/branch` and `branch` are the same thing in this context
   const headRefRegex = /^refs\/heads\//
   const targetCommitishName = targetCommitish.replace(headRefRegex, '')
-  const filteredReleases = filterByCommitish
+  const commitishFilteredReleases = filterByCommitish
     ? releases.filter(
         (r) =>
           targetCommitishName === r.target_commitish.replace(headRefRegex, '')
       )
     : releases
+  const filteredReleases = tagPrefix
+    ? commitishFilteredReleases.filter((r) => r.tag_name.startsWith(tagPrefix))
+    : commitishFilteredReleases
   const sortedPublishedReleases = sortReleases(
     filteredReleases.filter((r) => !r.draft)
   )
@@ -318,7 +322,8 @@ const generateReleaseInfo = ({
     // Use the first override parameter to identify
     // a version, from the most accurate to the least
     version || tag || name,
-    resolveVersionKeyIncrement(mergedPullRequests, config)
+    resolveVersionKeyIncrement(mergedPullRequests, config),
+    config['tag-prefix']
   )
 
   if (versionInfo) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -39,6 +39,10 @@ const schema = (context) => {
         .allow('')
         .default(DEFAULT_CONFIG['name-template']),
 
+      'tag-prefix': Joi.string()
+        .allow('')
+        .default(DEFAULT_CONFIG['tag-prefix']),
+
       'tag-template': Joi.string()
         .allow('')
         .default(DEFAULT_CONFIG['tag-template']),

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -136,24 +136,30 @@ const toSemver = (version) => {
   return semver.coerce(version)
 }
 
-const coerceVersion = (input) => {
+const coerceVersion = (input, tagPrefix) => {
   if (!input) {
     return
   }
 
+  const stripTag = (input) =>
+    tagPrefix && input.startsWith(tagPrefix)
+      ? input.slice(tagPrefix.length)
+      : input
+
   return typeof input === 'object'
-    ? toSemver(input.tag_name) || toSemver(input.name)
-    : toSemver(input)
+    ? toSemver(stripTag(input.tag_name)) || toSemver(stripTag(input.name))
+    : toSemver(stripTag(input))
 }
 
 const getVersionInfo = (
   release,
   template,
   inputVersion,
-  versionKeyIncrement
+  versionKeyIncrement,
+  tagPrefix
 ) => {
-  const version = coerceVersion(release)
-  inputVersion = coerceVersion(inputVersion)
+  const version = coerceVersion(release, tagPrefix)
+  inputVersion = coerceVersion(inputVersion, tagPrefix)
 
   if (!version && !inputVersion) {
     return defaultVersionInfo

--- a/schema.json
+++ b/schema.json
@@ -47,6 +47,18 @@
         }
       ]
     },
+    "tag-prefix": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [""]
+        },
+        {
+          "default": "",
+          "type": "string"
+        }
+      ]
+    },
     "tag-template": {
       "anyOf": [
         {

--- a/test/fixtures/config/config-with-tag-prefix.yml
+++ b/test/fixtures/config/config-with-tag-prefix.yml
@@ -1,0 +1,7 @@
+name-template: 'static-tag-prefix-v$RESOLVED_VERSION 🌈'
+tag-template: 'static-tag-prefix-v$RESOLVED_VERSION'
+tag-prefix: static-tag-prefix-v
+template: |
+  ## Previous release
+
+  $PREVIOUS_TAG


### PR DESCRIPTION
Extending #1084 with the rest of #935

- Include a configuration option to filter the draft tag by a static string prefix

A benefit of this is that if you use a `tag-template: v$RESOLVED_VERSION` and `tag-prefix: v`, prerelease versioning will be supported