### PR TITLE
Add a `collapse-after` option for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,12 +249,12 @@ Pull requests with the label "feature" or "fix" will now be grouped together:
 Adding such labels to your PRs can be automated by using the embedded Autolabeler functionality (see below),
 [PR Labeler](https://github.com/TimonVS/pr-labeler-action) or [Probot Auto Labeler](https://github.com/probot/autolabeler).
 
-Optionally you can add a `collapse` boolean to your category item, if the category has more than 3 pull requests then it will show all pull requests collapsed for that category. Append the `collapse` boolean to your category as following:
+Optionally you can add a `collapse-after` entry to your category item, if the category has more than the defined `collapse-after` pull requests then it will show all pull requests collapsed for that category. Append the `collapse-after` integer to your category as following:
 
 ```yml
 categories:
   - title: '⬆️ Dependencies'
-    collapse: true
+    collapse-after: 3
     labels:
       - 'dependencies'
 ```

--- a/README.md
+++ b/README.md
@@ -254,8 +254,9 @@ Optionally you can add a `collapse` boolean to your category item, if the catego
 ```yml
 categories:
   - title: '⬆️ Dependencies'
-    label: 'dependencies'
     collapse: true
+    labels:
+      - 'dependencies'
 ```
 
 ## Exclude Pull Requests

--- a/README.md
+++ b/README.md
@@ -249,6 +249,15 @@ Pull requests with the label "feature" or "fix" will now be grouped together:
 Adding such labels to your PRs can be automated by using the embedded Autolabeler functionality (see below),
 [PR Labeler](https://github.com/TimonVS/pr-labeler-action) or [Probot Auto Labeler](https://github.com/probot/autolabeler).
 
+Optionally you can add a `collapse` boolean to your category item, if the category has more than 3 pull requests then it will show all pull requests collapsed for that category. Append the `collapse` boolean to your category as following:
+
+```yml
+categories:
+  - title: '⬆️ Dependencies'
+    label: 'dependencies'
+    collapse: true
+```
+
 ## Exclude Pull Requests
 
 With the `exclude-labels` option you can exclude pull requests from the release notes using labels. For example, append the following to your `.github/release-drafter.yml` file:

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -246,9 +246,11 @@ const generateChangeLog = (mergedPullRequests, config) => {
     })
     const pullRequestString = pullRequestToString(category.pullRequests)
 
-    if (category.pullRequests.length <= category['collapse-after']) {
-      changeLog.push(categoryTitle, '\n\n', pullRequestString)
-    } else {
+    const shouldCollapse =
+      category['collapse-after'] != 0 &&
+      category.pullRequests.length > category['collapse-after']
+
+    if (shouldCollapse) {
       changeLog.push(
         categoryTitle,
         '\n\n',
@@ -260,6 +262,8 @@ const generateChangeLog = (mergedPullRequests, config) => {
         '\n',
         '</details>'
       )
+    } else {
+      changeLog.push(categoryTitle, '\n\n', pullRequestString)
     }
 
     if (index + 1 !== categorizedPullRequests.length) changeLog.push('\n\n')

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -247,7 +247,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
     const pullRequestString = pullRequestToString(category.pullRequests)
 
     const shouldCollapse =
-      category['collapse-after'] != 0 &&
+      category['collapse-after'] !== 0 &&
       category.pullRequests.length > category['collapse-after']
 
     if (shouldCollapse) {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -178,8 +178,8 @@ const categorizePullRequests = (pullRequests, config) => {
     .filter(getFilterIncludedPullRequests(includeLabels))
     .filter((pullRequest) => filterUncategorizedPullRequests(pullRequest))
 
-  categorizedPullRequests.map((category) => {
-    filteredPullRequests.map((pullRequest) => {
+  for (const category of categorizedPullRequests) {
+    for (const pullRequest of filteredPullRequests) {
       // lets categorize some pull request based on labels
       // note that having the same label in multiple categories
       // then it is intended to "duplicate" the pull request into each category
@@ -187,8 +187,8 @@ const categorizePullRequests = (pullRequests, config) => {
       if (labels.some((label) => category.labels.includes(label.name))) {
         category.pullRequests.push(pullRequest)
       }
-    })
-  })
+    }
+  }
 
   return [uncategorizedPullRequests, categorizedPullRequests]
 }
@@ -237,11 +237,10 @@ const generateChangeLog = (mergedPullRequests, config) => {
     changeLog.push(pullRequestToString(uncategorizedPullRequests), '\n\n')
   }
 
-  categorizedPullRequests.map((category, index) => {
+  for (const [index, category] of categorizedPullRequests.entries()) {
     if (category.pullRequests.length === 0) {
-      return category
+      continue
     }
-
     const categoryTitle = template(config['category-template'], {
       $TITLE: category.title,
     })
@@ -255,17 +254,19 @@ const generateChangeLog = (mergedPullRequests, config) => {
     } else {
       changeLog.push(
         categoryTitle,
+        '\n',
         '<details>',
         '\n',
         `<summary>${category.pullRequests.length} changes</summary>`,
         '\n\n',
         pullRequestString,
+        '\n',
         '</details>'
       )
     }
 
     if (index + 1 !== categorizedPullRequests.length) changeLog.push('\n\n')
-  })
+  }
 
   return changeLog.join('').trim()
 }

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -238,15 +238,33 @@ const generateChangeLog = (mergedPullRequests, config) => {
   }
 
   categorizedPullRequests.map((category, index) => {
-    if (category.pullRequests.length > 0) {
-      changeLog.push(
-        template(config['category-template'], { $TITLE: category.title }),
-        '\n\n',
-        pullRequestToString(category.pullRequests)
-      )
-
-      if (index + 1 !== categorizedPullRequests.length) changeLog.push('\n\n')
+    if (category.pullRequests.length === 0) {
+      return category
     }
+
+    const categoryTitle = template(config['category-template'], {
+      $TITLE: category.title,
+    })
+    const pullRequestString = pullRequestToString(category.pullRequests)
+
+    if (
+      !category.collapse ||
+      (category.collapse && category.pullRequests.length < 4)
+    ) {
+      changeLog.push(categoryTitle, '\n\n', pullRequestString)
+    } else {
+      changeLog.push(
+        categoryTitle,
+        '<details>',
+        '\n',
+        `<summary>${category.pullRequests.length} changes</summary>`,
+        '\n\n',
+        pullRequestString,
+        '</details>'
+      )
+    }
+
+    if (index + 1 !== categorizedPullRequests.length) changeLog.push('\n\n')
   })
 
   return changeLog.join('').trim()

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -241,19 +241,24 @@ const generateChangeLog = (mergedPullRequests, config) => {
     if (category.pullRequests.length === 0) {
       continue
     }
-    const categoryTitle = template(config['category-template'], {
-      $TITLE: category.title,
-    })
+
+    // Add the category title to the changelog.
+    changeLog.push(
+      template(config['category-template'], { $TITLE: category.title }),
+      '\n\n'
+    )
+
+    // Define the pull requests into a single string.
     const pullRequestString = pullRequestToString(category.pullRequests)
 
+    // Determine the collapse status.
     const shouldCollapse =
       category['collapse-after'] !== 0 &&
       category.pullRequests.length > category['collapse-after']
 
+    // Add the pull requests to the changelog.
     if (shouldCollapse) {
       changeLog.push(
-        categoryTitle,
-        '\n\n',
         '<details>',
         '\n',
         `<summary>${category.pullRequests.length} changes</summary>`,
@@ -263,7 +268,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
         '</details>'
       )
     } else {
-      changeLog.push(categoryTitle, '\n\n', pullRequestString)
+      changeLog.push(pullRequestString)
     }
 
     if (index + 1 !== categorizedPullRequests.length) changeLog.push('\n\n')

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -246,15 +246,12 @@ const generateChangeLog = (mergedPullRequests, config) => {
     })
     const pullRequestString = pullRequestToString(category.pullRequests)
 
-    if (
-      !category.collapse ||
-      (category.collapse && category.pullRequests.length < 4)
-    ) {
+    if (category.pullRequests.length <= category['collapse-after']) {
       changeLog.push(categoryTitle, '\n\n', pullRequestString)
     } else {
       changeLog.push(
         categoryTitle,
-        '\n',
+        '\n\n',
         '<details>',
         '\n',
         `<summary>${category.pullRequests.length} changes</summary>`,

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -111,7 +111,10 @@ const schema = (context) => {
           Joi.object()
             .keys({
               title: Joi.string().required(),
-              collapse: Joi.boolean().default(false),
+              'collapse-after': Joi.number()
+                .integer()
+                .min(0)
+                .default(Number.MAX_VALUE),
               label: Joi.string(),
               labels: Joi.array().items(Joi.string()).single().default([]),
             })

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -111,6 +111,7 @@ const schema = (context) => {
           Joi.object()
             .keys({
               title: Joi.string().required(),
+              collapse: Joi.boolean().default(false),
               label: Joi.string(),
               labels: Joi.array().items(Joi.string()).single().default([]),
             })

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -111,10 +111,7 @@ const schema = (context) => {
           Joi.object()
             .keys({
               title: Joi.string().required(),
-              'collapse-after': Joi.number()
-                .integer()
-                .min(0)
-                .default(Number.MAX_VALUE),
+              'collapse-after': Joi.number().integer().min(0).default(0),
               label: Joi.string(),
               labels: Joi.array().items(Joi.string()).single().default([]),
             })

--- a/schema.json
+++ b/schema.json
@@ -199,6 +199,10 @@
           "title": {
             "type": "string"
           },
+          "collapse": {
+            "default": false,
+            "type": "boolean"
+          },
           "label": {
             "type": "string"
           },

--- a/schema.json
+++ b/schema.json
@@ -200,7 +200,7 @@
             "type": "string"
           },
           "collapse-after": {
-            "default": 1.7976931348623157e308,
+            "default": 0,
             "type": "integer",
             "minimum": 0
           },

--- a/schema.json
+++ b/schema.json
@@ -199,9 +199,10 @@
           "title": {
             "type": "string"
           },
-          "collapse": {
-            "default": false,
-            "type": "boolean"
+          "collapse-after": {
+            "default": 1.7976931348623157e308,
+            "type": "integer",
+            "minimum": 0
           },
           "label": {
             "type": "string"

--- a/test/fixtures/config/config-with-categories-with-collapse-after.yml
+++ b/test/fixtures/config/config-with-categories-with-collapse-after.yml
@@ -5,7 +5,7 @@ template: |
 
 categories:
   - title: 🚀 All the things!
-    collapse: true
+    collapse-after: 3
     labels:
       - feature
       - enhancement

--- a/test/fixtures/config/config-with-categories-with-collapse.yml
+++ b/test/fixtures/config/config-with-categories-with-collapse.yml
@@ -1,0 +1,18 @@
+template: |
+  # What's Changed
+
+  $CHANGES
+
+categories:
+  - title: 🚀 All the things!
+    collapse: true
+    labels:
+      - feature
+      - enhancement
+      - fix
+      - bugfix
+      - bug
+      - sentry
+      - skip-changelog
+  - title: 👻 Maintenance
+    label: chore

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1200,7 +1200,7 @@ describe('release-drafter', () => {
       })
 
       it('categorizes pull requests with a collapsed category', async () => {
-        getConfigMock('config-with-categories-with-collapse.yml')
+        getConfigMock('config-with-categories-with-collapse-after.yml')
 
         nock('https://api.github.com')
           .get('/repos/toolmantim/release-drafter-test-project/releases')
@@ -1224,6 +1224,7 @@ describe('release-drafter', () => {
                 * Update dependencies (#4) @TimonVS
 
                 ## 🚀 All the things!
+
                 <details>
                 <summary>4 changes</summary>
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1198,6 +1198,60 @@ describe('release-drafter', () => {
 
         expect.assertions(1)
       })
+
+      it('categorizes pull requests with a collapsed category', async () => {
+        getConfigMock('config-with-categories-with-collapse.yml')
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body).toMatchInlineSnapshot(`
+                Object {
+                  "body": "# What's Changed
+
+                * Update dependencies (#4) @TimonVS
+
+                ## 🚀 All the things!
+                <details>
+                <summary>4 changes</summary>
+
+                * Add documentation (#5) @TimonVS
+                * Bug fixes (#3) @TimonVS
+                * Add big feature (#2) @TimonVS
+                * 👽 Add alien technology (#1) @TimonVS
+                </details>
+                ",
+                  "draft": true,
+                  "name": "",
+                  "prerelease": false,
+                  "tag_name": "",
+                  "target_commitish": "refs/heads/master",
+                }
+              `)
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+      })
     })
 
     describe('with exclude-labels config', () => {

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -187,5 +187,49 @@ describe('releases', () => {
         * Adds @<!---->nullable annotations to the 1\\\\*1+2\\\\*4 test in \\\\\`tests.java\\\\\` (#0) @Happypig375"
       `)
     })
+    it('adds proper details/summary markdown when collapse is set to true and more then 3 PRs', () => {
+      const config = {
+        ...baseConfig,
+        categories: [{ title: 'Bugs', collapse: true, labels: 'bug' }],
+      }
+      const changelog = generateChangeLog(pullRequests, config)
+      expect(changelog).toMatchInlineSnapshot(`
+        "* B2 (#2) @ghost
+        * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
+        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+
+        ## Bugs
+        <details>
+        <summary>5 changes</summary>
+
+        * A1 (#1) @ghost
+        * Adds missing <example> (#3) @jetersen
+        * \`#code_block\` (#4) @jetersen
+        * Fixes #4 (#5) @Happypig375
+        * 2*2 should equal to 4*1 (#6) @jetersen
+        </details>"
+      `)
+    })
+    it('does not add proper details/summary markdown when collapse is set to true and less then 3 PRs', () => {
+      const config = {
+        ...baseConfig,
+        categories: [{ title: 'Feature', collapse: true, labels: 'feature' }],
+      }
+      const changelog = generateChangeLog(pullRequests, config)
+      console.log(changelog)
+      expect(changelog).toMatchInlineSnapshot(`
+        "* A1 (#1) @ghost
+        * Adds missing <example> (#3) @jetersen
+        * \`#code_block\` (#4) @jetersen
+        * Fixes #4 (#5) @Happypig375
+        * 2*2 should equal to 4*1 (#6) @jetersen
+        * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
+
+        ## Feature
+
+        * B2 (#2) @ghost
+        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375"
+      `)
+    })
   })
 })

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -216,7 +216,6 @@ describe('releases', () => {
         categories: [{ title: 'Feature', collapse: true, labels: 'feature' }],
       }
       const changelog = generateChangeLog(pullRequests, config)
-      console.log(changelog)
       expect(changelog).toMatchInlineSnapshot(`
         "* A1 (#1) @ghost
         * Adds missing <example> (#3) @jetersen

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -187,7 +187,7 @@ describe('releases', () => {
         * Adds @<!---->nullable annotations to the 1\\\\*1+2\\\\*4 test in \\\\\`tests.java\\\\\` (#0) @Happypig375"
       `)
     })
-    it('adds proper details/summary markdown when collapse is set to true and more then 3 PRs', () => {
+    it('adds proper details/summary markdown when collapse is set to true and more than 3 PRs', () => {
       const config = {
         ...baseConfig,
         categories: [{ title: 'Bugs', collapse: true, labels: 'bug' }],
@@ -210,7 +210,7 @@ describe('releases', () => {
         </details>"
       `)
     })
-    it('does not add proper details/summary markdown when collapse is set to true and less then 3 PRs', () => {
+    it('does not add proper details/summary markdown when collapse is set to true and less than 3 PRs', () => {
       const config = {
         ...baseConfig,
         categories: [{ title: 'Feature', collapse: true, labels: 'feature' }],

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -187,10 +187,10 @@ describe('releases', () => {
         * Adds @<!---->nullable annotations to the 1\\\\*1+2\\\\*4 test in \\\\\`tests.java\\\\\` (#0) @Happypig375"
       `)
     })
-    it('adds proper details/summary markdown when collapse is set to true and more than 3 PRs', () => {
+    it('adds proper details/summary markdown when collapse-after is set and more than 3 PRs', () => {
       const config = {
         ...baseConfig,
-        categories: [{ title: 'Bugs', collapse: true, labels: 'bug' }],
+        categories: [{ title: 'Bugs', 'collapse-after': 3, labels: 'bug' }],
       }
       const changelog = generateChangeLog(pullRequests, config)
       expect(changelog).toMatchInlineSnapshot(`
@@ -199,6 +199,7 @@ describe('releases', () => {
         * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
 
         ## Bugs
+
         <details>
         <summary>5 changes</summary>
 
@@ -210,10 +211,12 @@ describe('releases', () => {
         </details>"
       `)
     })
-    it('does not add proper details/summary markdown when collapse is set to true and less than 3 PRs', () => {
+    it('does not add proper details/summary markdown when collapse-after is set and less than 3 PRs', () => {
       const config = {
         ...baseConfig,
-        categories: [{ title: 'Feature', collapse: true, labels: 'feature' }],
+        categories: [
+          { title: 'Feature', 'collapse-after': 3, labels: 'feature' },
+        ],
       }
       const changelog = generateChangeLog(pullRequests, config)
       expect(changelog).toMatchInlineSnapshot(`


### PR DESCRIPTION
This implements a new feature as discussed in #1093 

Add the `collapse-after` integer to a category to make it hide the PRs if there are more than the given int.