### PR TITLE
Interrupt create/update release if no commits available to categorize

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,25 +200,32 @@ module.exports = (app, { getRouter }) => {
     })
 
     let createOrUpdateReleaseResponse
-    if (!draftRelease) {
-      log({ context, message: 'Creating new release' })
-      createOrUpdateReleaseResponse = await createRelease({
+    if (commits.length === 0) {
+      log({
         context,
-        releaseInfo,
-        config,
+        message: 'Not creating a release, no commits to categorize',
       })
     } else {
-      log({ context, message: 'Updating existing release' })
-      createOrUpdateReleaseResponse = await updateRelease({
-        context,
-        draftRelease,
-        releaseInfo,
-        config,
-      })
-    }
+      if (!draftRelease) {
+        log({ context, message: 'Creating new release' })
+        createOrUpdateReleaseResponse = await createRelease({
+          context,
+          releaseInfo,
+          config,
+        })
+      } else {
+        log({ context, message: 'Updating existing release' })
+        createOrUpdateReleaseResponse = await updateRelease({
+          context,
+          draftRelease,
+          releaseInfo,
+          config,
+        })
+      }
 
-    if (runnerIsActions()) {
-      setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
+      if (runnerIsActions()) {
+        setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
+      }
     }
   }
 


### PR DESCRIPTION
My original fork had an early `return` to interrupt the rest of `drafter`, but I hadn't thought it through when I removed it when cleaning up my upstream contributions.

That early `return` was used to prevent drafting empty releases or empty draft releases. Since I've switched from my branch back to 5.19.0, I'm now getting those empty draft releases again.

My one question is whether

```javascript
      if (runnerIsActions()) {
        setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
      }
```
needs to be run always, or only during create/update. I believe it only makes sense to run during create/update, but I'm open to feedback.

Thanks!