### PR TITLE
Add more comments about pull requests permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write  # for release-drafter/release-drafter to create a github release
-      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set


### PR DESCRIPTION
Hi,

README introduces that permission required by pull-requests should be write when to add label to PR.
`pull-requests: write  # for release-drafter/release-drafter to add label to PR`

I think this comment can mislead some users to think they can remove this option, if they don't need add label functionality.
After remove this option. release-drafter complains about permissions. (related  [issue](https://github.com/release-drafter/release-drafter/issues/869))

So I suggest to add more information about permission. 
which introduces write permission is optional for autolabeler and read permission is required at least.

Thanks.