### PR TITLE
Add missing inputs to action config

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,16 @@ inputs:
       The object that the release should be created to point to.
     required: false
     default: ''
+  header:
+    description: |
+      A string that would be added before the template body.
+    required: false
+    default: ''
+  footer:
+    description: |
+      A string that would be added after the template body.
+    required: false
+    default: ''
   disable-releaser:
     description: |
       A boolean indicating whether the releaser mode is disabled.


### PR DESCRIPTION
Providing header or footer leads to a warning and the inputs are ignored
by the action. These two inputs are explicitly mentioned at
https://github.com/release-drafter/release-drafter#action-inputs. This
patch fixes the behavior to finally comply with the docs.