### PR TITLE
fetch 100 labels for pull requests instead of 10

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -74,7 +74,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   }
                   mergedAt
                   isCrossRepository
-                  labels(first: 10) {
+                  labels(first: 100) {
                     nodes {
                       name
                     }


### PR DESCRIPTION
# Issue

* we are using your great action in a setup with quite a lot of labels (one repository with multiple teams using [prow](https://github.com/kubernetes/test-infra/tree/master/prow))
* some PRs are not drafted as only the first 10 labels of each PR are fetched

# Solution

* fetch more labels of the pull requests in question

>Note: I am unsure what might be a good number (our setup normally comes with 10-20 labels). Would 100 be a performance issue?

Thanks in advance!

<sub>Mathias Zeller <mathias.zeller@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>