### PR TITLE
Only use last full release when drafting

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -57,7 +57,7 @@ const findReleases = async ({
     ? commitishFilteredReleases.filter((r) => r.tag_name.startsWith(tagPrefix))
     : commitishFilteredReleases
   const sortedPublishedReleases = sortReleases(
-    filteredReleases.filter((r) => !r.draft)
+    filteredReleases.filter((r) => !r.draft && !r.prerelease)
   )
   const draftRelease = filteredReleases.find((r) => r.draft)
   const lastRelease =


### PR DESCRIPTION
Also disregards pre-releases in addition to drafts when drafting.

Fixes: #1135
