### PR TITLE
fix(release): strip prefix before comparing version

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -5,11 +5,17 @@ const { getVersionInfo } = require('./versions')
 const { template } = require('./template')
 const { log } = require('./log')
 
-const sortReleases = (releases) => {
+const sortReleases = (releases, tagPrefix) => {
   // For semver, we find the greatest release number
   // For non-semver, we use the most recently merged
   try {
-    return releases.sort((r1, r2) => compareVersions(r1.tag_name, r2.tag_name))
+    const tagPrefixRexExp = new RegExp(`^${regexEscape(tagPrefix)}`)
+    return releases.sort((r1, r2) =>
+      compareVersions(
+        r1.tag_name.replace(tagPrefixRexExp, ''),
+        r2.tag_name.replace(tagPrefixRexExp, '')
+      )
+    )
   } catch {
     return releases.sort(
       (r1, r2) => new Date(r1.created_at) - new Date(r2.created_at)
@@ -60,7 +66,8 @@ const findReleases = async ({
   const sortedSelectedReleases = sortReleases(
     filteredReleases.filter(
       (r) => !r.draft && (!r.prerelease || includePreReleases)
-    )
+    ),
+    tagPrefix
   )
   const draftRelease = filteredReleases.find((r) => r.draft)
   const lastRelease = sortedSelectedReleases[sortedSelectedReleases.length - 1]


### PR DESCRIPTION
In documentation, it says 
> A known prefix used to filter release tags. For matching tags, this prefix is stripped before attempting to parse the version. Default: ""

However, while sorting version to retrieve the latest release, the prefix is taking into account and leads to sort regarding `created_at`, not semver