### PR TITLE
feat: handle release branching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `version-resolver`         | Optional | Adjust the `$RESOLVED_VERSION` variable using labels. Refer to [Version Resolver](#version-resolver) to learn more about this                                                      |
 | `commitish`                | Optional | The release target, i.e. branch or commit it should point to. Default: the ref that release-drafter runs for, e.g. `refs/heads/master` if configured to run on pushes to `master`. |
 | `filter-by-commitish`      | Optional | Filter previous releases to consider only those with the target matching `commitish`. Default: `false`.                                                                            |
+| `filter-by-regex`          | Optional | Filter previous releases to consider only those with the target matching this regex.                                                                                               |
 | `include-paths`            | Optional | Restrict pull requests included in the release notes to only the pull requests that modified any of the paths in this array. Supports files and directories. Default: `[]`         |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.

--- a/index.js
+++ b/index.js
@@ -154,6 +154,7 @@ module.exports = (app, { getRouter }) => {
 
     const {
       'filter-by-commitish': filterByCommitish,
+      'filter-by-regex': filterByRegex,
       'include-pre-releases': includePreReleases,
       'prerelease-identifier': preReleaseIdentifier,
       'tag-prefix': tagPrefix,
@@ -169,6 +170,7 @@ module.exports = (app, { getRouter }) => {
       context,
       targetCommitish,
       filterByCommitish,
+      filterByRegex,
       includePreReleases: shouldIncludePreReleases,
       tagPrefix,
     })

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -29,6 +29,7 @@ const findReleases = async ({
   context,
   targetCommitish,
   filterByCommitish,
+  filterByRegex,
   includePreReleases,
   tagPrefix,
 }) => {
@@ -59,9 +60,16 @@ const findReleases = async ({
           targetCommitishName === r.target_commitish.replace(headRefRegex, '')
       )
     : releases
-  const filteredReleases = tagPrefix
-    ? commitishFilteredReleases.filter((r) => r.tag_name.startsWith(tagPrefix))
+  const regexFilteredReleases = filterByRegex
+    ? commitishFilteredReleases.filter((r) =>
+        new RegExp(filterByRegex).test(
+          r.target_commitish.replace(headRefRegex, '')
+        )
+      )
     : commitishFilteredReleases
+  const filteredReleases = tagPrefix
+    ? regexFilteredReleases.filter((r) => r.tag_name.startsWith(tagPrefix))
+    : regexFilteredReleases
   const sortedSelectedReleases = sortReleases(
     filteredReleases.filter(
       (r) => !r.draft && (!r.prerelease || includePreReleases)


### PR DESCRIPTION
Hi! First of all, thank you for building this GH action. I've been using it for a while, and it works great!

I need to set it up in a project that uses the "Release Branching Strategy" (see http://releaseflow.org/).
In this flow, we have a unique branch name for every release, like so:
- `release-1.0.0` --> tag `1.0.0`
- `release-1.1.0` --> tag `1.1.0`
- etc...

To find the latest release that is not a hotfix (i.e. filter out releases created from `hotfix-**` branches), we would like to filter releases by testing their targets against a regex.

I've allowed myself to make this simple change that renders `release-drafter` compatible with this use case.
Let me know what you think. Thanks!