### PR TITLE
Add config option for PR query limit

### DIFF
--- a/bin/generate-fixtures.js
+++ b/bin/generate-fixtures.js
@@ -86,6 +86,7 @@ for (const repo of repos) {
         withPullRequestURL: true,
         withBaseRefName: true,
         withHeadRefName: true,
+        pullRequestLimit: 5,
       },
     })
   )

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -40,6 +40,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
     $after: String
     $withBaseRefName: Boolean!
     $withHeadRefName: Boolean!
+    $pullRequestLimit: Int!
   ) {
     repository(name: $name, owner: $owner) {
       object(expression: $targetCommitish) {
@@ -60,7 +61,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   login
                 }
               }
-              associatedPullRequests(first: 5) {
+              associatedPullRequests(first: $pullRequestLimit) {
                 nodes {
                   title
                   number
@@ -107,6 +108,7 @@ const findCommitsWithAssociatedPullRequests = async ({
     withPullRequestURL: config['change-template'].includes('$URL'),
     withBaseRefName: config['change-template'].includes('$BASE_REF_NAME'),
     withHeadRefName: config['change-template'].includes('$HEAD_REF_NAME'),
+    pullRequestLimit: config['pull-request-limit'],
   }
   const includePaths = config['include-paths']
   const dataPath = ['repository', 'object', 'history']

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG = Object.freeze({
   latest: 'true',
   'filter-by-commitish': false,
   commitish: '',
+  'pull-request-limit': 5,
   'category-template': `## $TITLE`,
   header: '',
   footer: '',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -95,6 +95,11 @@ const schema = (context) => {
 
       commitish: Joi.string().allow('').default(DEFAULT_CONFIG['commitish']),
 
+      'pull-request-limit': Joi.number()
+        .positive()
+        .integer()
+        .default(DEFAULT_CONFIG['pull-request-limit']),
+
       replacers: Joi.array()
         .items(
           Joi.object().keys({

--- a/test/fixtures/config/config-with-pull-request-limit.yml
+++ b/test/fixtures/config/config-with-pull-request-limit.yml
@@ -1,0 +1,2 @@
+template: '$CHANGES'
+pull-request-limit: 34

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -20,6 +20,7 @@ const validConfigs = [
   [{ template, header: 'I am on top' }],
   [{ template, footer: 'I am on bottm' }],
   [{ template, header: 'I am on top', footer: 'I am on bottm' }],
+  [{ template, 'pull-request-limit': 49 }],
 ]
 
 const invalidConfigs = [
@@ -53,6 +54,7 @@ const invalidConfigs = [
   ],
   [{ replacers: [{ search: '123', replace: 123 }] }, 'must be a string'],
   [{ commitish: false }, 'must be a string'],
+  [{ 'pull-request-limit': 'forty nine' }, 'must be a number'],
 ]
 
 describe('schema', () => {


### PR DESCRIPTION
Adds a configuration option to resolve the issue described in https://github.com/release-drafter/release-drafter/issues/1354, where long-lived PRs could cause others to be omitted from the release summary. This option allows users to increase the number of PRs the action searches when looking for a merged PR containing a given commit. The option is not required and defaults to 5 (the currently used value).

An alternate approach would be to simply increase the hard-coded limit in the existing query, although this could theoretically have an impact on API load for users not affected by the original issue.