### PR TITLE
Fix: Correctly mention bot accounts in release notes

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -68,6 +68,8 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   body @include(if: $withPullRequestBody)
                   author {
                     login
+                    __typename
+                    url
                   }
                   baseRepository {
                     nameWithOwner

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -111,7 +111,13 @@ const contributorsSentence = ({ commits, pullRequests, config }) => {
       pullRequest.author &&
       !excludeContributors.includes(pullRequest.author.login)
     ) {
-      contributors.add(`@${pullRequest.author.login}`)
+      if (pullRequest.author.__typename === 'Bot') {
+        contributors.add(
+          `[${pullRequest.author.login}[bot]](${pullRequest.author.url})`
+        )
+      } else {
+        contributors.add(`@${pullRequest.author.login}`)
+      }
     }
   }
 
@@ -235,17 +241,26 @@ const generateChangeLog = (mergedPullRequests, config) => {
 
   const pullRequestToString = (pullRequests) =>
     pullRequests
-      .map((pullRequest) =>
-        template(config['change-template'], {
+      .map((pullRequest) => {
+        var pullAuthor = 'ghost'
+        if (pullRequest.author) {
+          pullAuthor =
+            pullRequest.author.__typename &&
+            pullRequest.author.__typename === 'Bot'
+              ? `[${pullRequest.author.login}[bot]](${pullRequest.author.url})`
+              : pullRequest.author.login
+        }
+
+        return template(config['change-template'], {
           $TITLE: escapeTitle(pullRequest.title),
           $NUMBER: pullRequest.number,
-          $AUTHOR: pullRequest.author ? pullRequest.author.login : 'ghost',
+          $AUTHOR: pullAuthor,
           $BODY: pullRequest.body,
           $URL: pullRequest.url,
           $BASE_REF_NAME: pullRequest.baseRefName,
           $HEAD_REF_NAME: pullRequest.headRefName,
         })
-      )
+      })
       .join('\n')
 
   const changeLog = []

--- a/test/fixtures/__generated__/graphql-commits-forking.json
+++ b/test/fixtures/__generated__/graphql-commits-forking.json
@@ -27,7 +27,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -62,7 +64,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/28",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -86,7 +90,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -121,7 +127,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/27",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -141,7 +149,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -176,7 +186,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/25",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -203,7 +215,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -238,7 +252,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/25",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -265,7 +281,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -300,7 +318,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/24",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -327,7 +347,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -362,7 +384,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/23",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -389,7 +413,9 @@
                     "url": "https://github.com/jetersen/release-drafter-test-repo/pull/1",
                     "body": "No thanks to forking PRs",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "jetersen/release-drafter-test-repo"
@@ -424,7 +450,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -463,7 +491,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -502,7 +532,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -537,7 +569,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -572,7 +606,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"

--- a/test/fixtures/__generated__/graphql-commits-merge-commit.json
+++ b/test/fixtures/__generated__/graphql-commits-merge-commit.json
@@ -27,7 +27,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -66,7 +68,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -101,7 +105,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -143,7 +149,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -185,7 +193,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -224,7 +234,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -263,7 +275,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/5",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -302,7 +316,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -337,7 +353,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/4",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -372,7 +390,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -414,7 +434,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/3",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -456,7 +478,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -498,7 +522,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/2",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -540,7 +566,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/1",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"

--- a/test/fixtures/__generated__/graphql-commits-overlapping-label.json
+++ b/test/fixtures/__generated__/graphql-commits-overlapping-label.json
@@ -27,7 +27,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/22",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -66,7 +68,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/21",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -101,7 +105,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/20",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -146,7 +152,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/19",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -188,7 +196,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/18",
                     "body": "",
                     "author": {
-                      "login": "jetersen"
+                      "login": "jetersen",
+                      "__typename": "User",
+                      "url": "https://github.com/jetersen"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"

--- a/test/fixtures/__generated__/graphql-commits-rebase-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-rebase-merging.json
@@ -27,7 +27,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/10",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -66,7 +68,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/10",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -105,7 +109,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/9",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -140,7 +146,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/9",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -175,7 +183,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/8",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -217,7 +227,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/8",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -259,7 +271,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/7",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -301,7 +315,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/7",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -343,7 +359,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/6",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"

--- a/test/fixtures/__generated__/graphql-commits-squash-merging.json
+++ b/test/fixtures/__generated__/graphql-commits-squash-merging.json
@@ -27,7 +27,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/15",
                     "body": "✍️ writing docs all day",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -66,7 +68,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/14",
                     "body": "📦 Package time! 📦",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -101,7 +105,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/13",
                     "body": "🐛 squashing",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -143,7 +149,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/12",
                     "body": "![I'm kind of a big deal](https://media.giphy.com/media/9LFBOD8a1Ip2M/giphy.gif)",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"
@@ -185,7 +193,9 @@
                     "url": "https://github.com/toolmantim/release-drafter-test-project/pull/11",
                     "body": "Space invasion 👾",
                     "author": {
-                      "login": "TimonVS"
+                      "login": "TimonVS",
+                      "__typename": "User",
+                      "url": "https://github.com/TimonVS"
                     },
                     "baseRepository": {
                       "nameWithOwner": "toolmantim/release-drafter-test-project"

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -80,6 +80,21 @@ const pullRequests = [
     baseRefName: 'master',
     headRefName: 'implement-feature',
   },
+  {
+    title: 'Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples',
+    number: 0,
+    body: 'Updates the dependency ....',
+    url: 'https://github.com',
+    labels: { nodes: [{ name: 'dependencies' }] },
+    author: {
+      login: 'dependabot',
+      // although the RESTful API returns a `type: "Bot"`, GraphQL only allows us to look up based on the `__typename`
+      __typename: 'Bot',
+      url: 'https://github.com/apps/dependabot',
+    },
+    baseRefName: 'master',
+    headRefName: 'dependabot/go_modules/examples/golang.org/x/crypto-0.17.0',
+  },
 ]
 const baseConfig = {
   ...DEFAULT_CONFIG,
@@ -99,7 +114,8 @@ describe('releases', () => {
         * Fixes #4 (#5) @Happypig375
         * 2*2 should equal to 4*1 (#6) @jetersen
         * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
-        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375"
+        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('escapes titles with \\s correctly', () => {
@@ -116,7 +132,8 @@ describe('releases', () => {
         * Fixes #4 (#5) @Happypig375
         * 2*2 should equal to 4*1 (#6) @jetersen
         * Rename __confgs\\\\\\\\confg.yml to __configs\\\\\\\\config.yml (#7) @ghost
-        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375"
+        * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('escapes titles with \\<*_& correctly', () => {
@@ -133,7 +150,8 @@ describe('releases', () => {
         * Fixes #4 (#5) @Happypig375
         * 2\\\\*2 should equal to 4\\\\*1 (#6) @jetersen
         * Rename \\\\_\\\\_confgs\\\\\\\\confg.yml to \\\\_\\\\_configs\\\\\\\\config.yml (#7) @ghost
-        * Adds @nullable annotations to the 1\\\\*1+2\\\\*4 test in \`tests.java\` (#0) @Happypig375"
+        * Adds @nullable annotations to the 1\\\\*1+2\\\\*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('escapes titles with @s correctly', () => {
@@ -150,7 +168,8 @@ describe('releases', () => {
         * Fixes #4 (#5) @Happypig375
         * 2*2 should equal to 4*1 (#6) @jetersen
         * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
-        * Adds @<!---->nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375"
+        * Adds @<!---->nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('escapes titles with @s and #s correctly', () => {
@@ -167,7 +186,8 @@ describe('releases', () => {
         * Fixes #<!---->4 (#5) @Happypig375
         * 2*2 should equal to 4*1 (#6) @jetersen
         * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
-        * Adds @<!---->nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375"
+        * Adds @<!---->nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('escapes titles with \\<@*_&`# correctly', () => {
@@ -184,7 +204,8 @@ describe('releases', () => {
         * Fixes #<!---->4 (#5) @Happypig375
         * 2\\\\*2 should equal to 4\\\\*1 (#6) @jetersen
         * Rename \\\\_\\\\_confgs\\\\\\\\confg.yml to \\\\_\\\\_configs\\\\\\\\config.yml (#7) @ghost
-        * Adds @<!---->nullable annotations to the 1\\\\*1+2\\\\*4 test in \\\\\`tests.java\\\\\` (#0) @Happypig375"
+        * Adds @<!---->nullable annotations to the 1\\\\*1+2\\\\*4 test in \\\\\`tests.java\\\\\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
     it('adds proper details/summary markdown when collapse-after is set and more than 3 PRs', () => {
@@ -197,6 +218,7 @@ describe('releases', () => {
         "* B2 (#2) @ghost
         * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
         * Adds @nullable annotations to the 1*1+2*4 test in \`tests.java\` (#0) @Happypig375
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)
 
         ## Bugs
 
@@ -227,6 +249,7 @@ describe('releases', () => {
         * Fixes #4 (#5) @Happypig375
         * 2*2 should equal to 4*1 (#6) @jetersen
         * Rename __confgs\\\\confg.yml to __configs\\\\config.yml (#7) @ghost
+        * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)
 
         ## Feature
 


### PR DESCRIPTION
As noted in #60, bot accounts are currently being mis-mentioned, where
instead of linking through to `dependabot[bot]` it'll tag a user
`@dependabot` which isn't the same, and can result in unwanted
notifications.

To address this, we can retrieve the type of user that has authored a
Pull Request, looking at the `__typename` to determine if it's a `Bot`
or a `User` account, and provide a Markdown link to the Bot account's
app page.

Unfortunately this may result in a name such as:

@[dependabot[bot]](https://github.com/apps/dependabot)

But this is a better result than tagging the wrong account.

Closes #60.

