### PR TITLE
Update Node.js to 20

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: yarn
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.7.0-alpine@sha256:4c8f734f33b4c8bb41c3caf17c61e6828e45cdc39dcc3fd495d0fb3213b33cfe
+FROM node:20.11.0-alpine@sha256:9b61ed13fef9ca689326f40c0c0b4da70e37a18712f200b4c66d3b44fd59d98e
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 LABEL "repository"="https://github.com/release-drafter/release-drafter"

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Release Drafter'
 description: 'Drafts your next release notes as pull requests are merged into master.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: edit-2

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier": "2.7.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "jest": {
     "testEnvironment": "jest-environment-node",


### PR DESCRIPTION
fix https://github.com/release-drafter/release-drafter/issues/1378

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Node.js 16 actions are deprecated.
Therefore, I update Node.js used in this Action to 20.