### PR TITLE
Update only drafts with the same prerelease status

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -68,7 +68,9 @@ const findReleases = async ({
     ),
     tagPrefix
   )
-  const draftRelease = filteredReleases.find((r) => r.draft)
+  const draftRelease = filteredReleases.find(
+    (r) => r.draft && r.prerelease === includePreReleases
+  )
   const lastRelease = sortedSelectedReleases[sortedSelectedReleases.length - 1]
 
   if (draftRelease) {

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -318,6 +318,7 @@ describe('releases', () => {
       const { draftRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
+        includePreReleases: false,
         tagPrefix: '',
       })
 
@@ -332,20 +333,26 @@ describe('releases', () => {
       paginateMock.mockResolvedValueOnce([
         { tag_name: 'v1.0.0', draft: true, prerelease: false },
         { tag_name: 'v1.0.1', draft: false, prerelease: false },
-        { tag_name: 'v1.0.2-rc.1', draft: false, prerelease: true },
+        { tag_name: 'v1.0.2-rc.1', draft: true, prerelease: true },
       ])
 
-      const { lastRelease } = await findReleases({
+      const { draftRelease, lastRelease } = await findReleases({
         context,
         targetCommitish: 'refs/heads/master',
         tagPrefix: '',
         includePreReleases: true,
       })
 
-      expect(lastRelease).toEqual({
+      expect(draftRelease).toEqual({
         tag_name: 'v1.0.2-rc.1',
-        draft: false,
+        draft: true,
         prerelease: true,
+      })
+
+      expect(lastRelease).toEqual({
+        tag_name: 'v1.0.1',
+        draft: false,
+        prerelease: false,
       })
     })
   })


### PR DESCRIPTION
Do **not** update *final* release drafts with when drafting a *prerelease* and vice versa

Given the following releases:

Name | Draft | Prerelease
-- | -- | --
v3.4.0 |   |  
v3.5.0-rc.4 |   | ✅
v3.5.0 | ✅  |  
v3.5.0-rc.5 | ✅ | ✅

when running release-drafter with this config:

```
prerelease: true
prerelease-identifier: rc
```

I'd expect the draft of `v3.5.0-rc.5` to be updated instead of `v3.5.0`.

This allows me to maintain a draft for the next prerelease, listing the changes since the previous prerelease, and a draft for the next final release, listing the changes since the previous final release.
