### PR TITLE
Add GHA tag, name, & version to the release body template object

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ You can use any of the following variables in your `template`, `header`, `footer
 | `$NEXT_MINOR_VERSION` | The next minor version number. For example, if the last tag or release was `v1.2.3`, the value would be `v1.3.0`.                                       |
 | `$NEXT_MAJOR_VERSION` | The next major version number. For example, if the last tag or release was `v1.2.3`, the value would be `v2.0.0`.                                       |
 | `$RESOLVED_VERSION`   | The next resolved version number, based on GitHub labels. Refer to [Version Resolver](#version-resolver) to learn more about this.                      |
+| `$INPUT_TAG`          | The value of `tag` as passed in from the GitHub workflow.                                                                                               |
+| `$INPUT_NAME`         | The value of `name` as passed in from the GitHub workflow.                                                                                              |
+| `$INPUT_VERSION`      | The value of `version` as passed in from the GitHub workflow.                                                                                           |
 
 ## Version Template Variables
 

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -364,6 +364,9 @@ const generateReleaseInfo = ({
     body,
     {
       $PREVIOUS_TAG: lastRelease ? lastRelease.tag_name : '',
+      $RELEASE_TAG: tag,
+      $RELEASE_NAME: name,
+      $RELEASE_VERSION: version,
       $CHANGES: generateChangeLog(mergedPullRequests, config),
       $CONTRIBUTORS: contributorsSentence({
         commits,

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -364,9 +364,9 @@ const generateReleaseInfo = ({
     body,
     {
       $PREVIOUS_TAG: lastRelease ? lastRelease.tag_name : '',
-      $RELEASE_TAG: tag,
-      $RELEASE_NAME: name,
-      $RELEASE_VERSION: version,
+      $INPUT_TAG: tag,
+      $INPUT_NAME: name,
+      $INPUT_VERSION: version,
       $CHANGES: generateChangeLog(mergedPullRequests, config),
       $CONTRIBUTORS: contributorsSentence({
         commits,

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -123,4 +123,38 @@ describe('template', () => {
       'This is my body [https://issues.jenkins-ci.org/browse/JENKINS-1234](JENKINS-1234) [https://issues.jenkins-ci.org/browse/JENKINS-456](JENKINS-456)'
     )
   })
+  it('release tag replacer', () => {
+    const output = template('$RELEASE_TAG', {
+      $RELEASE_TAG: 'v1.0.0',
+    })
+    expect(output).toEqual('v1.0.0')
+  })
+  it('release name replacer', () => {
+    const output = template('$RELEASE_NAME', {
+      $RELEASE_NAME: 'hello world',
+    })
+    expect(output).toEqual('hello world')
+  })
+  it('release version replacer', () => {
+    const output = template('$RELEASE_VERSION', {
+      $RELEASE_VERSION: 'v2',
+    })
+    expect(output).toEqual('v2')
+  })
+  it('all version info replaced', () => {
+    const tag = 2
+    const version = `v${tag}`
+    const name = `Beta release (${version})`
+
+    const output = template(
+      `tag: $RELEASE_TAG\nversion: $RELEASE_VERSION\nname: $RELEASE_NAME`,
+      {
+        $RELEASE_TAG: tag,
+        $RELEASE_VERSION: version,
+        $RELEASE_NAME: name,
+      }
+    )
+
+    expect(output).toEqual(`tag: ${tag}\nversion: ${version}\nname: ${name}`)
+  })
 })

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -124,20 +124,20 @@ describe('template', () => {
     )
   })
   it('release tag replacer', () => {
-    const output = template('$RELEASE_TAG', {
-      $RELEASE_TAG: 'v1.0.0',
+    const output = template('$INPUT_TAG', {
+      $INPUT_TAG: 'v1.0.0',
     })
     expect(output).toEqual('v1.0.0')
   })
   it('release name replacer', () => {
-    const output = template('$RELEASE_NAME', {
-      $RELEASE_NAME: 'hello world',
+    const output = template('$INPUT_NAME', {
+      $INPUT_NAME: 'hello world',
     })
     expect(output).toEqual('hello world')
   })
   it('release version replacer', () => {
-    const output = template('$RELEASE_VERSION', {
-      $RELEASE_VERSION: 'v2',
+    const output = template('$INPUT_VERSION', {
+      $INPUT_VERSION: 'v2',
     })
     expect(output).toEqual('v2')
   })
@@ -147,11 +147,11 @@ describe('template', () => {
     const name = `Beta release (${version})`
 
     const output = template(
-      `tag: $RELEASE_TAG\nversion: $RELEASE_VERSION\nname: $RELEASE_NAME`,
+      `tag: $INPUT_TAG\nversion: $INPUT_VERSION\nname: $INPUT_NAME`,
       {
-        $RELEASE_TAG: tag,
-        $RELEASE_VERSION: version,
-        $RELEASE_NAME: name,
+        $INPUT_TAG: tag,
+        $INPUT_VERSION: version,
+        $INPUT_NAME: name,
       }
     )
 


### PR DESCRIPTION
## What's changed
Adds support for `template` replacement of the following [action input variables](https://github.com/release-drafter/release-drafter?tab=readme-ov-file#action-inputs) in `.github/release-drafter.yml`:
| Variable    | Description      |
| ------------- | ------------- |
| `$INPUT_TAG` | `input.tag` from GHA workflow |
| `$INPUT_NAME` | `input.name` from GHA workflow |
| `$INPUT_VERSION` | `input.version` from GHA workflow |

## Reason / Use case
I am using the `input.version` action input to pass in a specific version for the drafted release without using `$NEXT_PATCH_VERSION`, `$NEXT_MINOR_VERSION`, `$NEXT_MAJOR_VERSION`, `$RESOLVED_VERSION` etc. I want to also be able to use this inputted value in the body of the release draft, but noticed it is not supported in any of the template variable sections here, and not passed into `template()` in `generateReleaseInfo()` ([link](https://github.com/release-drafter/release-drafter/blob/77cfd858cefea596b8ac500960670555b15f43bb/lib/releases.js#L365)).




