### PR TITLE
Document added action outputs introduced in #1300

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,14 +377,18 @@ The Release Drafter GitHub Action accepts a number of optional inputs directly i
 
 The Release Drafter GitHub Action sets a couple of outputs which can be used as inputs to other Actions in the workflow ([example](https://github.com/actions/upload-release-asset#example-workflow---upload-a-release-asset)).
 
-| Output       | Description                                                                                                                                                                                                                   |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`         | The ID of the release that was created or updated.                                                                                                                                                                            |
-| `name`       | The name of this release.                                                                                                                                                                                                     |
-| `tag_name`   | The name of the tag associated with this release.                                                                                                                                                                             |
-| `body`       | The body of the drafted release, useful if it needs to be included in files.                                                                                                                                                  |
-| `html_url`   | The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`.                                                                                                    |
-| `upload_url` | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset GitHub Action`](https://www.github.com/actions/upload-release-asset). |
+| Output             | Description                                                                                                                                                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | The ID of the release that was created or updated.                                                                                                                                                                            |
+| `name`             | The name of this release.                                                                                                                                                                                                     |
+| `tag_name`         | The name of the tag associated with this release.                                                                                                                                                                             |
+| `body`             | The body of the drafted release, useful if it needs to be included in files.                                                                                                                                                  |
+| `html_url`         | The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`.                                                                                                    |
+| `upload_url`       | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset GitHub Action`](https://www.github.com/actions/upload-release-asset). |
+| `resolved_version` | Version resolved by [Version Resolver](#version-resolver). i.e. `6.3.1`                                                                                                                                                       |
+| `major_version`    | Major part of resolved version by [Version Resolver](#version-resolver). i.e. `6` for version `6.3.1`                                                                                                                         |
+| `minor_version`    | Minor part of resolved version by [Version Resolver](#version-resolver). i.e. `3` for version `6.3.1`                                                                                                                         |
+| `patch_version`    | Patch part of resolved version by [Version Resolver](#version-resolver). i.e. `1` for version `6.3.1`                                                                                                                         |
 
 ## Developing
 


### PR DESCRIPTION
in #1300 the following action outputs were added, but not added to the readme documentation: `resolved_version`, `major_version`, `minor_version` and `patch_version`


*(accidetally deleted my fork of this repo and that lead to the first instance of this PR (#1405)  getting closed, sorry)*