### PR TITLE
feat: Add support for ref comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `commitish`                | Optional | The release target, i.e. branch or commit it should point to. Default: the ref that release-drafter runs for, e.g. `refs/heads/master` if configured to run on pushes to `master`. |
 | `filter-by-commitish`      | Optional | Filter previous releases to consider only those with the target matching `commitish`. Default: `false`.                                                                            |
 | `include-paths`            | Optional | Restrict pull requests included in the release notes to only the pull requests that modified any of the paths in this array. Supports files and directories. Default: `[]`         |
+| `use-ref-comparison`                 | Optional | Use ref comparison to find commits for drafting release notes. By default commits are listed by date since last release. Default: `false`         |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -180,7 +180,12 @@ const findCommitsWithAssociatedPullRequests = async ({
       context.octokit.graphql,
       diffCommitsWithAssociatedPullRequestsQuery,
       { ...variables, baseRef: `refs/tags/${lastRelease.tag_name}` },
-      dataPath
+      [
+        'repository',
+        'ref',
+        'compare',
+        'commits',
+      ]
     )
     allCommits = _.get(data, [
       'repository',

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -92,6 +92,68 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
   }
 `
 
+const diffCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
+  query diffCommitsWithAssociatedPullRequests(
+    $name: String!
+    $owner: String!
+    $baseRef: String!
+    $targetCommitish: String!
+    $withPullRequestBody: Boolean!
+    $withPullRequestURL: Boolean!
+    $withBaseRefName: Boolean!
+    $withHeadRefName: Boolean!
+  ) {
+    repository(name: $name, owner: $owner) {
+      ref(qualifiedName: $baseRef) {
+        compare(headRef: $targetCommitish) {
+          commits(first: 100) {
+            totalCount
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              committedDate
+              message
+              author {
+                name
+                user {
+                  login
+                }
+              }
+              associatedPullRequests(first: 5) {
+                nodes {
+                  title
+                  number
+                  url @include(if: $withPullRequestURL)
+                  body @include(if: $withPullRequestBody)
+                  author {
+                    login
+                  }
+                  baseRepository {
+                    nameWithOwner
+                  }
+                  mergedAt
+                  isCrossRepository
+                  labels(first: 100) {
+                    nodes {
+                      name
+                    }
+                  }
+                  merged
+                  baseRefName @include(if: $withBaseRefName)
+                  headRefName @include(if: $withHeadRefName)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
 const findCommitsWithAssociatedPullRequests = async ({
   context,
   targetCommitish,
@@ -109,6 +171,7 @@ const findCommitsWithAssociatedPullRequests = async ({
     withHeadRefName: config['change-template'].includes('$HEAD_REF_NAME'),
   }
   const includePaths = config['include-paths']
+  const useDiff = config['use-diff']
   const dataPath = ['repository', 'object', 'history']
   const repoNameWithOwner = `${owner}/${repo}`
 
@@ -142,7 +205,20 @@ const findCommitsWithAssociatedPullRequests = async ({
     }
   }
 
-  if (lastRelease) {
+  if (lastRelease && useDiff) {
+    log({
+      context,
+      message: `Fetching commits in diff ${lastRelease.tag_name}...${targetCommitish}`,
+    })
+
+    data = await paginate(
+      context.octokit.graphql,
+      diffCommitsWithAssociatedPullRequestsQuery,
+      { ...variables, baseRef: `refs/tags/${lastRelease.tag_name}` },
+      dataPath
+    )
+    allCommits = _.get(data, [...dataPath, 'nodes'])
+  } else if (lastRelease) {
     log({
       context,
       message: `Fetching parent commits of ${targetCommitish} since ${lastRelease.created_at}`,

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -29,6 +29,49 @@ const findCommitsWithPathChangesQuery = /* GraphQL */ `
   }
 `
 
+const _commitAndPullRequestQuery = /* GraphQL */ `
+totalCount
+pageInfo {
+  hasNextPage
+  endCursor
+}
+nodes {
+  id
+  committedDate
+  message
+  author {
+    name
+    user {
+      login
+    }
+  }
+  associatedPullRequests(first: 5) {
+    nodes {
+      title
+      number
+      url @include(if: $withPullRequestURL)
+      body @include(if: $withPullRequestBody)
+      author {
+        login
+      }
+      baseRepository {
+        nameWithOwner
+      }
+      mergedAt
+      isCrossRepository
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+      merged
+      baseRefName @include(if: $withBaseRefName)
+      headRefName @include(if: $withHeadRefName)
+    }
+  }
+}
+`
+
 const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
   query findCommitsWithAssociatedPullRequests(
     $name: String!
@@ -45,46 +88,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
       object(expression: $targetCommitish) {
         ... on Commit {
           history(first: 100, since: $since, after: $after) {
-            totalCount
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
-            nodes {
-              id
-              committedDate
-              message
-              author {
-                name
-                user {
-                  login
-                }
-              }
-              associatedPullRequests(first: 5) {
-                nodes {
-                  title
-                  number
-                  url @include(if: $withPullRequestURL)
-                  body @include(if: $withPullRequestBody)
-                  author {
-                    login
-                  }
-                  baseRepository {
-                    nameWithOwner
-                  }
-                  mergedAt
-                  isCrossRepository
-                  labels(first: 100) {
-                    nodes {
-                      name
-                    }
-                  }
-                  merged
-                  baseRefName @include(if: $withBaseRefName)
-                  headRefName @include(if: $withHeadRefName)
-                }
-              }
-            }
+            ${_commitAndPullRequestQuery}
           }
         }
       }
@@ -107,46 +111,7 @@ const diffCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
       ref(qualifiedName: $baseRef) {
         compare(headRef: $targetCommitish) {
           commits(first: 100) {
-            totalCount
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
-            nodes {
-              id
-              committedDate
-              message
-              author {
-                name
-                user {
-                  login
-                }
-              }
-              associatedPullRequests(first: 5) {
-                nodes {
-                  title
-                  number
-                  url @include(if: $withPullRequestURL)
-                  body @include(if: $withPullRequestBody)
-                  author {
-                    login
-                  }
-                  baseRepository {
-                    nameWithOwner
-                  }
-                  mergedAt
-                  isCrossRepository
-                  labels(first: 100) {
-                    nodes {
-                      name
-                    }
-                  }
-                  merged
-                  baseRefName @include(if: $withBaseRefName)
-                  headRefName @include(if: $withHeadRefName)
-                }
-              }
-            }
+            ${_commitAndPullRequestQuery}
           }
         }
       }

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -171,7 +171,7 @@ const findCommitsWithAssociatedPullRequests = async ({
     withHeadRefName: config['change-template'].includes('$HEAD_REF_NAME'),
   }
   const includePaths = config['include-paths']
-  const useDiff = config['use-diff']
+  const useRefComparison = config['use-ref-comparison']
   const dataPath = ['repository', 'object', 'history']
   const repoNameWithOwner = `${owner}/${repo}`
 
@@ -205,7 +205,7 @@ const findCommitsWithAssociatedPullRequests = async ({
     }
   }
 
-  if (lastRelease && useDiff) {
+  if (lastRelease && useRefComparison) {
     log({
       context,
       message: `Fetching commits in diff ${lastRelease.tag_name}...${targetCommitish}`,

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -180,12 +180,7 @@ const findCommitsWithAssociatedPullRequests = async ({
       context.octokit.graphql,
       diffCommitsWithAssociatedPullRequestsQuery,
       { ...variables, baseRef: `refs/tags/${lastRelease.tag_name}` },
-      [
-        'repository',
-        'ref',
-        'compare',
-        'commits',
-      ]
+      ['repository', 'ref', 'compare', 'commits']
     )
     allCommits = _.get(data, [
       'repository',

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -182,7 +182,13 @@ const findCommitsWithAssociatedPullRequests = async ({
       { ...variables, baseRef: `refs/tags/${lastRelease.tag_name}` },
       dataPath
     )
-    allCommits = _.get(data, [...dataPath, 'nodes'])
+    allCommits = _.get(data, [
+      'repository',
+      'ref',
+      'compare',
+      'commits',
+      'nodes',
+    ])
   } else if (lastRelease) {
     log({
       context,

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -29,7 +29,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'include-pre-releases': false,
   latest: 'true',
   'filter-by-commitish': false,
-  'use-diff': false,
+  'use-ref-comparison': false,
   commitish: '',
   'category-template': `## $TITLE`,
   header: '',

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -29,6 +29,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'include-pre-releases': false,
   latest: 'true',
   'filter-by-commitish': false,
+  'use-diff': false,
   commitish: '',
   'category-template': `## $TITLE`,
   header: '',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -138,7 +138,9 @@ const schema = (context) => {
         )
         .default(DEFAULT_CONFIG.categories),
 
-      'use-diff': Joi.boolean().default(DEFAULT_CONFIG['use-diff']),
+      'use-ref-comparison': Joi.boolean().default(
+        DEFAULT_CONFIG['use-ref-comparison']
+      ),
 
       'version-resolver': Joi.object()
         .keys({

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -138,6 +138,8 @@ const schema = (context) => {
         )
         .default(DEFAULT_CONFIG.categories),
 
+      'use-diff': Joi.boolean().default(DEFAULT_CONFIG['use-diff']),
+
       'version-resolver': Joi.object()
         .keys({
           major: Joi.object({


### PR DESCRIPTION
This project is great ❤️ 

I've found myself using it more and more, however I've found that it does not work as I'd expect for some git workflows, specifically when using "merge commits" to the branch where `release-drafter` is configured.

This is happening because `release-drafter` uses the date of the last release to list commits to draft a new release, however if commits were merged with an earlier date they get ignored!

This PR adds a configuration option to support such workflows in a backwards-compatible way.