### PR TITLE
Fix: Move changelog empty check after categorization for accuracy

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -219,12 +219,20 @@ const categorizePullRequests = (pullRequests, config) => {
 }
 
 const generateChangeLog = (mergedPullRequests, config) => {
-  if (mergedPullRequests.length === 0) {
-    return config['no-changes-template']
-  }
-
   const [uncategorizedPullRequests, categorizedPullRequests] =
-    categorizePullRequests(mergedPullRequests, config)
+    categorizePullRequests(mergedPullRequests, config);
+
+  const categorizedPullRequestsCount = categorizedPullRequests.reduce(
+      (sum, category) => sum + category.pullRequests.length,
+      0
+  );
+  
+  const totalPullRequestsInChangelog =
+      categorizedPullRequestsCount + uncategorizedPullRequests.length;
+  
+  if (totalPullRequestsInChangelog === 0) {
+      return config['no-changes-template'];
+  }
 
   const escapeTitle = (title) =>
     // If config['change-title-escapes'] contains backticks, then they will be escaped along with content contained inside backticks


### PR DESCRIPTION
Previously, the changelog check was based on `mergedPullRequests.length`, which could be misleading since some PRs might be filtered out or uncategorized. This change ensures the check happens after categorization, making sure only meaningful PRs are considered.

- Moved the "no changes" check after PR categorization
- Improved accuracy by counting only categorized and uncategorized PRs
- Optimized changelog generation by preventing unnecessary processing

Fixes potential issues where a release might be marked as having changes when none remain after filtering.