### PR TITLE
feat(autolabeler): purge labels that do not match anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,12 @@ replacers:
 You can add automatically a label into a pull request, with the `autolabeler` option. Available matchers are `files` (glob), `branch` (regex), `title` (regex) and `body` (regex).
 Matchers are evaluated independently; the label will be set if at least one of the matchers meets the criteria.
 
+To purge a label if it is present on the pull request but none of the criteria match anymore, set the `purge` property to `true`.
+
 ```yml
 autolabeler:
   - label: 'chore'
+    purge: true
     files:
       - '*.md'
     branch:
@@ -335,6 +338,7 @@ autolabeler:
     title:
       - '/fix/i'
   - label: 'enhancement'
+    purge: true
     branch:
       - '/feature\/.+/'
     body:

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -119,6 +119,7 @@ const schema = (context) => {
         .items(
           Joi.object().keys({
             label: Joi.string().required(),
+            purge: Joi.boolean().default(false),
             files: Joi.array().items(Joi.string()).single().default([]),
             branch: Joi.array().items(Joi.string()).single().default([]),
             title: Joi.array().items(Joi.string()).single().default([]),

--- a/schema.json
+++ b/schema.json
@@ -5,7 +5,9 @@
   "properties": {
     "references": {
       "type": "array",
-      "default": ["master"],
+      "default": [
+        "master"
+      ],
       "items": {
         "type": "string"
       }
@@ -73,12 +75,18 @@
     "sort-by": {
       "type": "string",
       "default": "merged_at",
-      "enum": ["merged_at", "title"]
+      "enum": [
+        "merged_at",
+        "title"
+      ]
     },
     "sort-direction": {
       "type": "string",
       "default": "descending",
-      "enum": ["ascending", "descending"]
+      "enum": [
+        "ascending",
+        "descending"
+      ]
     },
     "prerelease": {
       "type": "boolean",
@@ -104,6 +112,11 @@
       "type": "string",
       "default": ""
     },
+    "pull-request-limit": {
+      "type": "number",
+      "default": 5,
+      "exclusiveMinimum": 0
+    },
     "replacers": {
       "type": "array",
       "default": [],
@@ -117,7 +130,10 @@
             "type": "string"
           }
         },
-        "required": ["search", "replace"],
+        "required": [
+          "search",
+          "replace"
+        ],
         "additionalProperties": false
       }
     },
@@ -129,6 +145,10 @@
         "properties": {
           "label": {
             "type": "string"
+          },
+          "purge": {
+            "type": "boolean",
+            "default": false
           },
           "files": {
             "type": "array",
@@ -159,7 +179,9 @@
             }
           }
         },
-        "required": ["label"],
+        "required": [
+          "label"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,7 +210,9 @@
             }
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -249,7 +273,11 @@
         "default": {
           "type": "string",
           "default": "patch",
-          "enum": ["major", "minor", "patch"]
+          "enum": [
+            "major",
+            "minor",
+            "patch"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
By starting the set of labels for a pull request with the current labels, adding as usual, and purging if configured to purge and criteria is not met anymore, the actual set of labels can be PUT to the pull request.

Fixes: #1432