### PR TITLE
Update README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you're unable to use GitHub Actions, you can use the Release Drafter GitHub A
 
 ## Configuration
 
-Once you’ve added Release Drafter to your repository, it must be enabled by adding a `.github/release-drafter.yml` configuration file to each repository. The configuration file **must** reside in your default branch, no other configurations will be accepted.
+Once you’ve added Release Drafter to your repository, it must be enabled by adding a `.github/release-drafter.yml` configuration file to your repository. The configuration file **must** reside in your default branch, no other configurations will be accepted.
 
 ### Example
 


### PR DESCRIPTION
just a typo I found while reading the Readme. The reference should be for a single repository

Before: "Once you’ve added Release Drafter to **your** repository, it must be enabled by adding a `.github/release-drafter.yml` configuration file to **each** repository."

After: "Once you’ve added Release Drafter to **your** repository, it must be enabled by adding a `.github/release-drafter.yml` configuration file to **your** repository."