### PR TITLE
feat: allow dry runs to generate output without actually editing a re…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,11 @@ inputs:
       A boolean indicating whether the releaser mode is disabled.
     required: false
     default: ''
+  dry-release:
+    description: |
+      A boolean indicating whether the action should run in dry mode. If true, the action will not create or update a release.
+    required: false
+    default: ''
   disable-autolabeler:
     description: |
       A boolean indicating whether the autolabeler mode is disabled.

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -53,6 +53,11 @@ inputs:
       A boolean indicating whether the releaser mode is disabled.
     required: false
     default: ''
+  dry-release:
+    description: |
+      A boolean indicating whether the action should run in dry mode. If true, the action will not create or update a release.
+    required: false
+    default: ''
   disable-autolabeler:
     description: |
       A boolean indicating whether the autolabeler mode is disabled.


### PR DESCRIPTION
…lease

This may be useful for workflows (like mine) where 
* we want to leverage all the logic to find the right tag for the next release but don't create anything yet.
* use the output of the previous step to do some more custom logic on top of it (in my case, for a js package, bumping the version in package.json)
* create a PR with the version bump for someone to review and merged once we want to release
* only when that PR gets merged, use release drafter again to actually generate the Github release and publish it