### PR TITLE
feat: allow always collapsing a category

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -287,7 +287,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
 
     // Determine the collapse status.
     const shouldCollapse =
-      category['collapse-after'] !== 0 &&
+      category['collapse-after'] !== -1 &&
       category.pullRequests.length > category['collapse-after']
 
     // Add the pull requests to the changelog.
@@ -295,7 +295,9 @@ const generateChangeLog = (mergedPullRequests, config) => {
       changeLog.push(
         '<details>',
         '\n',
-        `<summary>${category.pullRequests.length} changes</summary>`,
+        `<summary>${category.pullRequests.length} change${
+          category.pullRequests.length > 1 ? 's' : ''
+        }</summary>`,
         '\n\n',
         pullRequestString,
         '\n',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -132,7 +132,7 @@ const schema = (context) => {
           Joi.object()
             .keys({
               title: Joi.string().required(),
-              'collapse-after': Joi.number().integer().min(0).default(0),
+              'collapse-after': Joi.number().integer().min(-1).default(-1),
               label: Joi.string(),
               labels: Joi.array().items(Joi.string()).single().default([]),
             })

--- a/schema.json
+++ b/schema.json
@@ -104,6 +104,11 @@
       "type": "string",
       "default": ""
     },
+    "pull-request-limit": {
+      "type": "number",
+      "default": 5,
+      "exclusiveMinimum": 0
+    },
     "replacers": {
       "type": "array",
       "default": [],
@@ -174,8 +179,8 @@
           },
           "collapse-after": {
             "type": "integer",
-            "default": 0,
-            "minimum": 0
+            "default": -1,
+            "minimum": -1
           },
           "label": {
             "type": "string"

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -208,6 +208,22 @@ describe('releases', () => {
         * Bump golang.org/x/crypto from 0.14.0 to 0.17.0 in /examples (#0) @[dependabot[bot]](https://github.com/apps/dependabot)"
       `)
     })
+    it('adds proper details/summary markdown when collapse-after is set to 0 and has a PR', () => {
+      const config = {
+        ...baseConfig,
+        categories: [{ title: 'Bugs', 'collapse-after': 0, labels: 'bug' }],
+      }
+      const changelog = generateChangeLog(pullRequests.slice(0, 1), config)
+      expect(changelog).toMatchInlineSnapshot(`
+        "## Bugs
+
+        <details>
+        <summary>1 change</summary>
+
+        * A1 (#1) @ghost
+        </details>"
+      `)
+    })
     it('adds proper details/summary markdown when collapse-after is set and more than 3 PRs', () => {
       const config = {
         ...baseConfig,


### PR DESCRIPTION
This patch allows setting the `collapse-after` key to 0 in order to
always collapse a category. This is useful in cases where you have
entries in multiple categories, and you want to by default hide the
"duplicate" categories.
