### PR TITLE
feat: support filter by base ref name

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -108,7 +108,10 @@ const findCommitsWithAssociatedPullRequests = async ({
     targetCommitish,
     withPullRequestBody: config['change-template'].includes('$BODY'),
     withPullRequestURL: config['change-template'].includes('$URL'),
-    withBaseRefName: config['change-template'].includes('$BASE_REF_NAME'),
+    withBaseRefName:
+      config['change-template'].includes('$BASE_REF_NAME') ||
+      config['exclude-base-ref-names']?.length > 0 ||
+      config['include-base-ref-names']?.length > 0,
     withHeadRefName: config['change-template'].includes('$HEAD_REF_NAME'),
     pullRequestLimit: config['pull-request-limit'],
   }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -17,6 +17,8 @@ const DEFAULT_CONFIG = Object.freeze({
   categories: [],
   'exclude-labels': [],
   'include-labels': [],
+  'exclude-base-ref-names': [],
+  'include-base-ref-names': [],
   'include-paths': [],
   'exclude-contributors': [],
   'no-contributors-template': 'No contributors',

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -137,26 +137,39 @@ const contributorsSentence = ({ commits, pullRequests, config }) => {
   }
 }
 
-const getFilterExcludedPullRequests = (excludeLabels) => {
+const getFilterExcludedPullRequests = (excludeLabels, excludeBaseRefNames) => {
   return (pullRequest) => {
     const labels = pullRequest.labels.nodes
     if (labels.some((label) => excludeLabels.includes(label.name))) {
+      return false
+    }
+    const prBaseRefName = pullRequest.baseRefName
+    if (excludeBaseRefNames.includes(prBaseRefName)) {
       return false
     }
     return true
   }
 }
 
-const getFilterIncludedPullRequests = (includeLabels) => {
+const getFilterIncludedPullRequests = (includeLabels, includeBaseRefNames) => {
   return (pullRequest) => {
     const labels = pullRequest.labels.nodes
+    let includeByLabels,
+      includeByBaseRefNames = false
     if (
       includeLabels.length === 0 ||
       labels.some((label) => includeLabels.includes(label.name))
     ) {
-      return true
+      includeByLabels = true
     }
-    return false
+    const prBaseRefName = pullRequest.baseRefName
+    if (
+      includeBaseRefNames.length === 0 ||
+      includeBaseRefNames.includes(prBaseRefName)
+    ) {
+      includeByBaseRefNames = true
+    }
+    return includeByLabels && includeByBaseRefNames
   }
 }
 
@@ -164,6 +177,8 @@ const categorizePullRequests = (pullRequests, config) => {
   const {
     'exclude-labels': excludeLabels,
     'include-labels': includeLabels,
+    'exclude-base-ref-names': excludeBaseRefNames,
+    'include-base-ref-names': includeBaseRefNames,
     categories,
   } = config
   const allCategoryLabels = new Set(
@@ -199,8 +214,8 @@ const categorizePullRequests = (pullRequests, config) => {
 
   // we only want pull requests that have yet to be categorized
   const filteredPullRequests = pullRequests
-    .filter(getFilterExcludedPullRequests(excludeLabels))
-    .filter(getFilterIncludedPullRequests(includeLabels))
+    .filter(getFilterExcludedPullRequests(excludeLabels, excludeBaseRefNames))
+    .filter(getFilterIncludedPullRequests(includeLabels, includeBaseRefNames))
     .filter((pullRequest) => filterUncategorizedPullRequests(pullRequest))
 
   for (const category of categorizedPullRequests) {
@@ -333,8 +348,18 @@ const resolveVersionKeyIncrement = (
   core.debug('labelToKeyMap: ' + JSON.stringify(labelToKeyMap))
 
   const keys = mergedPullRequests
-    .filter(getFilterExcludedPullRequests(config['exclude-labels']))
-    .filter(getFilterIncludedPullRequests(config['include-labels']))
+    .filter(
+      getFilterExcludedPullRequests(
+        config['exclude-labels'],
+        config['exclude-base-ref-names']
+      )
+    )
+    .filter(
+      getFilterIncludedPullRequests(
+        config['include-labels'],
+        config['include-base-ref-names']
+      )
+    )
     .flatMap((pr) => pr.labels.nodes.map((node) => labelToKeyMap[node.name]))
     .filter(Boolean)
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -55,6 +55,14 @@ const schema = (context) => {
         .items(Joi.string())
         .default(DEFAULT_CONFIG['include-labels']),
 
+      'exclude-base-ref-names': Joi.array()
+        .items(Joi.string())
+        .default(DEFAULT_CONFIG['exclude-base-ref-names']),
+
+      'include-base-ref-names': Joi.array()
+        .items(Joi.string())
+        .default(DEFAULT_CONFIG['include-base-ref-names']),
+
       'include-paths': Joi.array()
         .items(Joi.string())
         .default(DEFAULT_CONFIG['include-paths']),

--- a/schema.json
+++ b/schema.json
@@ -52,6 +52,20 @@
         "type": "string"
       }
     },
+    "exclude-base-ref-names": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "include-base-ref-names": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "include-paths": {
       "type": "array",
       "default": [],


### PR DESCRIPTION
this pr add two parameters (`exclude-base-ref-names` and `include-base-ref-names`) to support filter by base ref names, which can be used in case like only take account PR to specific branch like `main`. examples:

```
# file .github/release-drafter.yml
exclude-labels:
  - 'skip changelog'
  - 'reverted'
include-base-ref-names:
  - 'main'

```