### PR TITLE
Reduce query from first 100 to first 10

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -44,7 +44,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
     repository(name: $name, owner: $owner) {
       object(expression: $targetCommitish) {
         ... on Commit {
-          history(first: 100, since: $since, after: $after) {
+          history(first: 10, since: $since, after: $after) {
             totalCount
             pageInfo {
               hasNextPage
@@ -74,7 +74,7 @@ const findCommitsWithAssociatedPullRequestsQuery = /* GraphQL */ `
                   }
                   mergedAt
                   isCrossRepository
-                  labels(first: 100) {
+                  labels(first: 10) {
                     nodes {
                       name
                     }


### PR DESCRIPTION
This pull request makes adjustments to the GraphQL query in `lib/commits.js` to reduce the number of items fetched for both commit history and pull request labels. These changes help optimize performance and reduce unnecessary data transfer.

Query optimization:

* Reduced the number of commits fetched in the `history` field from 100 to 10 in the `findCommitsWithAssociatedPullRequestsQuery` GraphQL query.
* Limited the number of labels fetched for each pull request from 100 to 10 in the same query.