### PR TITLE
fix: implement disable-releaser and disable-autolabeler inputs

### DIFF
--- a/dist/actions/autolabeler/run.js
+++ b/dist/actions/autolabeler/run.js
@@ -1,6 +1,9 @@
-import { C as warning, S as setOutput, T as __toESM, b as info, g as context, h as getOctokit, l as object, m as composeConfigGet, o as array, r as sharedInputSchema, t as stringToRegex, u as string, w as __commonJSMin, x as setFailed, y as getInput } from "../../chunks/common.js";
+import { C as warning, S as setOutput, T as __toESM, b as info, d as stringbool, g as context, h as getOctokit, l as object, m as composeConfigGet, o as array, r as sharedInputSchema, s as boolean, t as stringToRegex, u as string, w as __commonJSMin, x as setFailed, y as getInput } from "../../chunks/common.js";
 //#region src/actions/autolabeler/config/action-input.schema.ts
-var actionInputSchema = object({ "config-name": string().optional().default("release-drafter.yml") }).and(sharedInputSchema);
+var actionInputSchema = object({
+	"config-name": string().optional().default("release-drafter.yml"),
+	"disable-autolabeler": stringbool().or(boolean()).optional()
+}).and(sharedInputSchema);
 //#endregion
 //#region src/actions/autolabeler/config/config.schema.ts
 var configSchema = object({ autolabeler: array(object({
@@ -20,7 +23,8 @@ var getActionInput = () => {
 	return actionInputSchema.parse({
 		"config-name": getInput$1("config-name"),
 		token: getInput$1("token"),
-		"dry-run": getInput$1("dry-run")
+		"dry-run": getInput$1("dry-run"),
+		"disable-autolabeler": getInput$1("disable-autolabeler")
 	});
 };
 //#endregion
@@ -372,6 +376,10 @@ var main = async (params) => {
 async function run() {
 	try {
 		const input = getActionInput();
+		if (input["disable-autolabeler"]) {
+			info("Autolabeler is disabled via disable-autolabeler input. Skipping labeling.");
+			return;
+		}
 		const { labels, pr_number } = await main({
 			config: parseConfig({ config: await getConfig(input["config-name"]) }),
 			dryRun: input["dry-run"]

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -25,7 +25,8 @@ var actionInputSchema = object({
 	name: string().optional(),
 	tag: string().optional(),
 	version: string().optional(),
-	publish: stringbool().optional().default(false)
+	publish: stringbool().optional().default(false),
+	"disable-releaser": stringbool().or(boolean()).optional()
 }).and(sharedInputSchema).and(commonConfigSchema);
 //#endregion
 //#region src/actions/drafter/config/get-action-inputs.ts
@@ -38,6 +39,7 @@ var getActionInput = () => {
 		version: getInput$1("version"),
 		publish: getInput$1("publish"),
 		token: getInput$1("token"),
+		"disable-releaser": getInput$1("disable-releaser"),
 		latest: getInput$1("latest"),
 		prerelease: getInput$1("prerelease"),
 		"initial-commits-since": getInput$1("initial-commits-since"),
@@ -2232,6 +2234,10 @@ async function run() {
 	try {
 		info("Parsing inputs and configuration...");
 		const input = getActionInput();
+		if (input["disable-releaser"]) {
+			info("Releaser is disabled via disable-releaser input. Skipping release creation.");
+			return;
+		}
 		const { upsertedRelease, releasePayload } = await main({
 			input,
 			config: mergeInputAndConfig({

--- a/src/actions/autolabeler/config/action-input.schema.ts
+++ b/src/actions/autolabeler/config/action-input.schema.ts
@@ -1,6 +1,6 @@
 import { sharedInputSchema } from 'src/common'
 import type * as z from 'zod'
-import { object, string } from 'zod'
+import { boolean, object, string, stringbool } from 'zod'
 
 export const actionInputSchema = object({
   /**
@@ -9,6 +9,11 @@ export const actionInputSchema = object({
    * @default 'release-drafter.yml'
    */
   'config-name': string().optional().default('release-drafter.yml'),
+  /**
+   * A boolean indicating whether the autolabeler mode is disabled.
+   * When true, the autolabeler will skip labeling entirely.
+   */
+  'disable-autolabeler': stringbool().or(boolean()).optional(),
 }).and(sharedInputSchema)
 
 /**

--- a/src/actions/autolabeler/config/get-action-inputs.ts
+++ b/src/actions/autolabeler/config/get-action-inputs.ts
@@ -12,5 +12,6 @@ export const getActionInput = (): ActionInput => {
     'config-name': getInput('config-name'),
     token: getInput('token'),
     'dry-run': getInput('dry-run'),
+    'disable-autolabeler': getInput('disable-autolabeler'),
   })
 }

--- a/src/actions/autolabeler/runner.ts
+++ b/src/actions/autolabeler/runner.ts
@@ -10,6 +10,12 @@ import { main } from './main'
 export async function run(): Promise<void> {
   try {
     const input = getActionInput()
+
+    if (input['disable-autolabeler']) {
+      core.info('Autolabeler is disabled via disable-autolabeler input. Skipping labeling.')
+      return
+    }
+
     const config = parseConfig({
       config: await getConfig(input['config-name']),
     })

--- a/src/actions/drafter/config/get-action-inputs.ts
+++ b/src/actions/drafter/config/get-action-inputs.ts
@@ -20,6 +20,7 @@ export const getActionInput = (): ActionInput => {
     version: getInput('version'),
     publish: getInput('publish'),
     token: getInput('token'),
+    'disable-releaser': getInput('disable-releaser'),
 
     // can override the config
     latest: getInput('latest'),

--- a/src/actions/drafter/config/schemas/action-input.schema.ts
+++ b/src/actions/drafter/config/schemas/action-input.schema.ts
@@ -1,6 +1,6 @@
 import { sharedInputSchema } from 'src/common'
 import type * as z from 'zod'
-import { object, string, stringbool } from 'zod'
+import { boolean, object, string, stringbool } from 'zod'
 import { commonConfigSchema } from './common-config.schema'
 
 export const exclusiveInputSchema = object({
@@ -29,6 +29,11 @@ export const exclusiveInputSchema = object({
    * A boolean indicating whether the release being created or updated should be immediately published.
    */
   publish: stringbool().optional().default(false),
+  /**
+   * A boolean indicating whether the releaser mode is disabled.
+   * When true, the drafter will skip release creation/update entirely.
+   */
+  'disable-releaser': stringbool().or(boolean()).optional(),
 }).and(sharedInputSchema)
 
 export const actionInputSchema = exclusiveInputSchema.and(commonConfigSchema)

--- a/src/actions/drafter/runner.ts
+++ b/src/actions/drafter/runner.ts
@@ -16,6 +16,12 @@ export async function run(): Promise<void> {
   try {
     core.info('Parsing inputs and configuration...')
     const input = getActionInput()
+
+    if (input['disable-releaser']) {
+      core.info('Releaser is disabled via disable-releaser input. Skipping release creation.')
+      return
+    }
+
     const config = mergeInputAndConfig({
       config: await getConfig(input['config-name']),
       input,


### PR DESCRIPTION
## Summary

The `disable-releaser` and `disable-autolabeler` inputs are defined in `action.yml` (and `drafter/action.yml`) but were never wired into the TypeScript source or compiled JavaScript. They were silently accepted but completely ignored.

This broke the **least-privilege split-workflow pattern** where:
- The autolabeler workflow runs with `contents: read` and `disable-releaser: true`
- The release drafter workflow runs with `contents: write` and `disable-autolabeler: true`

When `disable-releaser: true` was set but ignored, the drafter unconditionally attempted to create a release and failed with:
```
Error: Resource not accessible by integration
```

## Changes

### Drafter (`src/actions/drafter/`)
- **`config/schemas/action-input.schema.ts`** — Added `disable-releaser` boolean field to `exclusiveInputSchema`
- **`config/get-action-inputs.ts`** — Added `disable-releaser` to the `getActionInput()` function
- **`runner.ts`** — Added early-exit check: when `disable-releaser` is truthy, logs an info message and returns before any release operations

### Autolabeler (`src/actions/autolabeler/`)
- **`config/action-input.schema.ts`** — Added `disable-autolabeler` boolean field to `actionInputSchema`
- **`config/get-action-inputs.ts`** — Added `disable-autolabeler` to the `getActionInput()` function
- **`runner.ts`** — Added early-exit check: when `disable-autolabeler` is truthy, logs an info message and returns before any labeling operations

### Compiled output
- Rebuilt `dist/actions/drafter/run.js` and `dist/actions/autolabeler/run.js` to include the fix

## Testing

- All 304 existing tests pass (`npx vitest run`)
- Verified the compiled dist files contain the new input parsing and early-exit logic via `grep`

## Affected versions

- v7.0.0 (`3a7fb5c8`)
- v7.1.0 (`44a942e4`)

Fixes #1562