### PR TITLE
fix(initial-commits-since): override via input not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 permissions:
-  contents: read
+  contents: write # Required for "Set coverage status"
   statuses: write
 
 jobs:

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -957,6 +957,10 @@ var mergeInputAndConfig = (params) => {
 		if (config["filter-by-range"] && config["filter-by-range"] !== input["filter-by-range"]) info(`Input's filter-by-range "${input["filter-by-range"]}" overrides config's filter-by-range "${config["filter-by-range"]}"`);
 		config["filter-by-range"] = input["filter-by-range"];
 	}
+	if (input["initial-commits-since"]) {
+		if (config["initial-commits-since"] && config["initial-commits-since"] !== input["initial-commits-since"]) info(`Input's initial-commits-since "${input["initial-commits-since"]}" overrides config's initial-commits-since "${config["initial-commits-since"]}"`);
+		config["initial-commits-since"] = input["initial-commits-since"];
+	}
 	const commitish = config.commitish || context.ref || context.payload.ref;
 	const latest = typeof config.latest !== "boolean" ? true : config.latest;
 	const prerelease = typeof config.prerelease !== "boolean" ? false : config.prerelease;

--- a/src/actions/drafter/config/merge-input-and-config.ts
+++ b/src/actions/drafter/config/merge-input-and-config.ts
@@ -110,6 +110,18 @@ export const mergeInputAndConfig = (params: {
     config['filter-by-range'] = input['filter-by-range']
   }
 
+  if (input['initial-commits-since']) {
+    if (
+      config['initial-commits-since'] &&
+      config['initial-commits-since'] !== input['initial-commits-since']
+    ) {
+      core.info(
+        `Input's initial-commits-since "${input['initial-commits-since']}" overrides config's initial-commits-since "${config['initial-commits-since']}"`,
+      )
+    }
+    config['initial-commits-since'] = input['initial-commits-since']
+  }
+
   // Write defaults
   const commitish =
     config.commitish || context.ref || (context.payload.ref as string)

--- a/src/tests/drafter/merge-input-and-config.test.ts
+++ b/src/tests/drafter/merge-input-and-config.test.ts
@@ -135,6 +135,24 @@ describe('mergeInputAndConfig', () => {
       )
     })
 
+    it('should merge input and config with input taking precedence for initial-commits-since', () => {
+      const config = configSchema.parse({
+        template: '$CHANGES',
+        commitish: 'main',
+        'initial-commits-since': '2026-03-30T00:00:00Z',
+      })
+      const input = commonConfigSchema.parse({
+        'initial-commits-since': '2026-03-27T00:00:00Z',
+      })
+
+      const result = mergeInputAndConfig({ config, input })
+
+      expect(result['initial-commits-since']).toBe('2026-03-27T00:00:00Z')
+      expect(mocks.core.info).toHaveBeenCalledWith(
+        'Input\'s initial-commits-since "2026-03-27T00:00:00Z" overrides config\'s initial-commits-since "2026-03-30T00:00:00Z"',
+      )
+    })
+
     it('should use config values when input values are not provided', () => {
       const config = configSchema.parse({
         template: '$CHANGES',


### PR DESCRIPTION
First of all thanks for your work 👍 

I was testing out the release drafter action and while doing a initial release I was trying to leverage the `initial-commits-since` property via the action inputs however I noticed it wasn't producing any effect (the repo is large so it was basically trying to pickup everything since the beginning of time I guess).

I believe this a bug, consequence of `initial-commits-since` not being set in - https://github.com/release-drafter/release-drafter/blob/8a1e7e7867896b504dede2455891b90cff66cc2b/src/actions/drafter/config/merge-input-and-config.ts#L15-L45

So it will never be hand over to the main execution function.