### PR TITLE
Fixed initial-commits-since in config not being overwritten by input

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -957,6 +957,10 @@ var mergeInputAndConfig = (params) => {
 		if (config["filter-by-range"] && config["filter-by-range"] !== input["filter-by-range"]) info(`Input's filter-by-range "${input["filter-by-range"]}" overrides config's filter-by-range "${config["filter-by-range"]}"`);
 		config["filter-by-range"] = input["filter-by-range"];
 	}
+	if (input["initial-commits-since"]) {
+		if (config["initial-commits-since"] && config["initial-commits-since"] !== input["initial-commits-since"]) info(`Input's initial-commits-since "${input["initial-commits-since"]}" overrides config's initial-commits-since "${config["initial-commits-since"]}"`);
+		config["initial-commits-since"] = input["initial-commits-since"];
+	}
 	const commitish = config.commitish || context.ref || context.payload.ref;
 	const latest = typeof config.latest !== "boolean" ? true : config.latest;
 	const prerelease = typeof config.prerelease !== "boolean" ? false : config.prerelease;

--- a/src/actions/drafter/config/merge-input-and-config.ts
+++ b/src/actions/drafter/config/merge-input-and-config.ts
@@ -110,6 +110,18 @@ export const mergeInputAndConfig = (params: {
     config['filter-by-range'] = input['filter-by-range']
   }
 
+  if (input['initial-commits-since']) {
+    if (
+      config['initial-commits-since'] &&
+      config['initial-commits-since'] !== input['initial-commits-since']
+    ) {
+      core.info(
+        `Input's initial-commits-since "${input['initial-commits-since']}" overrides config's initial-commits-since "${config['initial-commits-since']}"`,
+      )
+    }
+    config['initial-commits-since'] = input['initial-commits-since']
+  }
+
   // Write defaults
   const commitish =
     config.commitish || context.ref || (context.payload.ref as string)

--- a/src/tests/drafter/merge-input-and-config.test.ts
+++ b/src/tests/drafter/merge-input-and-config.test.ts
@@ -135,6 +135,24 @@ describe('mergeInputAndConfig', () => {
       )
     })
 
+    it('should merge input and config with input taking precedence for initial-commits-since', () => {
+      const config = configSchema.parse({
+        template: '$CHANGES',
+        commitish: 'main',
+        'initial-commits-since': '2026-04-13T12:07:48Z',
+      })
+      const input = commonConfigSchema.parse({
+        'initial-commits-since': '2026-04-10T11:05:32Z',
+      })
+
+      const result = mergeInputAndConfig({ config, input })
+
+      expect(result['initial-commits-since']).toBe('2026-04-10T11:05:32Z')
+      expect(mocks.core.info).toHaveBeenCalledWith(
+        'Input\'s initial-commits-since "2026-04-10T11:05:32Z" overrides config\'s initial-commits-since "2026-04-13T12:07:48Z"',
+      )
+    })
+
     it('should use config values when input values are not provided', () => {
       const config = configSchema.parse({
         template: '$CHANGES',


### PR DESCRIPTION
Currently the `initial-commits-since` input variable is not overwriting the config value, resulting in it not being used. This PR fixes that by adding it to the merge function.