### PR TITLE
fix: initial-commits-since in config not overwritten by input

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -941,6 +941,7 @@ var applyOverrides = (config, input) => {
 	applyBooleanOverride(config, input, "include-pre-releases");
 	applyBooleanOverride(config, input, "latest");
 	applyStringOverride(config, input, "filter-by-range");
+	applyStringOverride(config, input, "initial-commits-since");
 	applyReleaseModeOverrides(config, input);
 };
 var applyReleaseModeOverrides = (config, input) => {

--- a/src/actions/drafter/config/merge-input-and-config.ts
+++ b/src/actions/drafter/config/merge-input-and-config.ts
@@ -73,6 +73,7 @@ const applyOverrides = (config: MutableConfig, input: CommonConfig) => {
   applyBooleanOverride(config, input, 'include-pre-releases')
   applyBooleanOverride(config, input, 'latest')
   applyStringOverride(config, input, 'filter-by-range')
+  applyStringOverride(config, input, 'initial-commits-since')
 
   applyReleaseModeOverrides(config, input)
 }

--- a/src/tests/drafter/merge-input-and-config.test.ts
+++ b/src/tests/drafter/merge-input-and-config.test.ts
@@ -135,6 +135,24 @@ describe('mergeInputAndConfig', () => {
       )
     })
 
+    it('should merge input and config with input taking precedence for initial-commits-since', () => {
+      const config = configSchema.parse({
+        template: '$CHANGES',
+        commitish: 'main',
+        'initial-commits-since': '2026-04-13T12:07:48Z',
+      })
+      const input = commonConfigSchema.parse({
+        'initial-commits-since': '2026-04-10T11:05:32Z',
+      })
+
+      const result = mergeInputAndConfig({ config, input })
+
+      expect(result['initial-commits-since']).toBe('2026-04-10T11:05:32Z')
+      expect(mocks.core.info).toHaveBeenCalledWith(
+        'Input\'s initial-commits-since "2026-04-10T11:05:32Z" overrides config\'s initial-commits-since "2026-04-13T12:07:48Z"',
+      )
+    })
+
     it('should use config values when input values are not provided', () => {
       const config = configSchema.parse({
         template: '$CHANGES',


### PR DESCRIPTION
Currently the initial-commits-since input variable is not overwriting the config value, resulting in it not being used. This PR fixes that by adding it to the merge function.

I created a new PR with correct branch naming, original was https://github.com/release-drafter/release-drafter/pull/1591