### PR TITLE
fix: restore prerelease-identifier on first run when no prior releases exist

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -1672,6 +1672,12 @@ var getVersionInfo = (params) => {
 	} else if (versionFromLastRelease.version) {
 		_localIncrement = _localIncrement?.startsWith("pre") && versionFromLastRelease?.prerelease?.length ? "prerelease" : _localIncrement;
 		referenceVersion = versionFromLastRelease;
+	} else if (_versionKeyIncrement?.startsWith("pre") && config["prerelease-identifier"]) {
+		_localIncrement = "no_increment";
+		referenceVersion = new VersionDescriptor(`0.1.0-${config["prerelease-identifier"]}.0`, {
+			preReleaseIdentifier: config["prerelease-identifier"],
+			tagPrefix: config["tag-prefix"]
+		});
 	} else {
 		_localIncrement = "no_increment";
 		referenceVersion = new VersionDescriptor("0.1.0", {

--- a/src/actions/drafter/lib/build-release-payload/get-version-info.ts
+++ b/src/actions/drafter/lib/build-release-payload/get-version-info.ts
@@ -69,11 +69,33 @@ export const getVersionInfo = (params: {
         : _localIncrement
     referenceVersion = versionFromLastRelease
   } else {
-    _localIncrement = 'no_increment' // stay at 0.1.0 since no version was provided / found
-    referenceVersion = new VersionDescriptor('0.1.0', {
-      preReleaseIdentifier: config['prerelease-identifier'],
-      tagPrefix: config['tag-prefix'],
-    })
+    // No prior release and no input version: start from 0.1.0.
+    // For prerelease-based increments (prepatch/preminor/premajor) with a
+    // prerelease-identifier, build the reference as "0.1.0-<identifier>.0" and
+    // use no_increment, so $RESOLVED_VERSION = "0.1.0-rc.0" — a prerelease *of*
+    // the initial version rather than a prerelease of the next incremented
+    // version (which semver's prepatch/preminor/premajor would otherwise
+    // produce, e.g. "0.1.1-rc.0").  This restores the v6 behaviour introduced
+    // in PR #1303.
+    if (
+      _versionKeyIncrement?.startsWith('pre') &&
+      config['prerelease-identifier']
+    ) {
+      _localIncrement = 'no_increment'
+      referenceVersion = new VersionDescriptor(
+        `0.1.0-${config['prerelease-identifier']}.0`,
+        {
+          preReleaseIdentifier: config['prerelease-identifier'],
+          tagPrefix: config['tag-prefix'],
+        },
+      )
+    } else {
+      _localIncrement = 'no_increment'
+      referenceVersion = new VersionDescriptor('0.1.0', {
+        preReleaseIdentifier: config['prerelease-identifier'],
+        tagPrefix: config['tag-prefix'],
+      })
+    }
   }
 
   return {

--- a/src/tests/drafter/get-version-info.test.ts
+++ b/src/tests/drafter/get-version-info.test.ts
@@ -220,6 +220,71 @@ describe('versions', () => {
     )
   })
 
+  it('uses prerelease-identifier on first run when versionKeyIncrement is prerelease-based', () => {
+    // Regression test: v7 broke v6 behaviour (PR #1303) where first-run with a
+    // prerelease-identifier set produced a bare version (e.g. "0.1.0") instead
+    // of a prerelease of the initial version (e.g. "0.1.0-rc.0").
+    // semver's prepatch would normally give "0.1.1-rc.0" (increments patch
+    // before adding the prerelease suffix), but on first run there is no prior
+    // release to increment from, so the result should be "0.1.0-rc.0".
+    const versionInfo = getVersionInfo({
+      lastRelease: undefined,
+      input: {},
+      config: {
+        'version-template': '$MAJOR.$MINOR.$PATCH$PRERELEASE',
+        'prerelease-identifier': 'rc',
+      },
+      versionKeyIncrement: 'prepatch',
+    })
+
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0-rc.0')
+    expect(versionInfo.$RESOLVED_VERSION_PRERELEASE).toEqual('-rc.0')
+  })
+
+  it('uses prerelease-identifier on first run with custom prerelease identifier', () => {
+    const versionInfo = getVersionInfo({
+      lastRelease: undefined,
+      input: {},
+      config: {
+        'version-template': '$MAJOR.$MINOR.$PATCH$PRERELEASE',
+        'prerelease-identifier': 'beta',
+      },
+      versionKeyIncrement: 'preminor',
+    })
+
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0-beta.0')
+    expect(versionInfo.$RESOLVED_VERSION_PRERELEASE).toEqual('-beta.0')
+  })
+
+  it('uses premajor prerelease-identifier on first run', () => {
+    const versionInfo = getVersionInfo({
+      lastRelease: undefined,
+      input: {},
+      config: {
+        'version-template': '$MAJOR.$MINOR.$PATCH$PRERELEASE',
+        'prerelease-identifier': 'rc',
+      },
+      versionKeyIncrement: 'premajor',
+    })
+
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0-rc.0')
+    expect(versionInfo.$RESOLVED_VERSION_PRERELEASE).toEqual('-rc.0')
+  })
+
+  it('still returns bare 0.1.0 on first run when versionKeyIncrement is not prerelease-based', () => {
+    const versionInfo = getVersionInfo({
+      lastRelease: undefined,
+      input: {},
+      config: {
+        'version-template': '$MAJOR.$MINOR.$PATCH',
+        'prerelease-identifier': 'rc',
+      },
+      versionKeyIncrement: 'patch',
+    })
+
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0')
+  })
+
   it('applies custom version template when no previous releases exist', () => {
     const versionInfo = getVersionInfo({
       lastRelease: undefined,


### PR DESCRIPTION
Resolves #1601

When no prior release exists and no input version is provided, the `else` branch in `getVersionInfo` forced `_localIncrement` to `'no_increment'`, which made `$RESOLVED_VERSION` return a bare version (e.g. `0.1.0`) regardless of the `prerelease-identifier` and `versionKeyIncrement` config.

This broke workflows that rely on prerelease-based increments (`prepatch`/`preminor`/`premajor`) to produce an RC-tagged version on first run (e.g. `0.1.0-rc.0`).

The v6 code (`lib/versions.js`, PR #1303) explicitly handled this case: when `versionKeyIncrement` started with `'pre'`, it returned the hardcoded `$NEXT_PRERELEASE_VERSION` default (`0.1.0-rc.0`) as `$RESOLVED_VERSION`. That behaviour was lost during the v7 TypeScript rewrite (PR #1475).

**Fix:** in the no-prior-release `else` branch, when `versionKeyIncrement` is prerelease-based and `prerelease-identifier` is set, initialise the reference version directly as `0.1.0-<identifier>.0` and use `no_increment`. This produces `$RESOLVED_VERSION = 0.1.0-rc.0` — a prerelease *of* the initial version — matching v6 behaviour. Regular increments (`patch`/`minor`/`major`) and configs without a `prerelease-identifier` are unchanged.

Examples with `prerelease-identifier: rc` and no prior release:
```
prepatch → 0.1.0-rc.0  (was: 0.1.0)
preminor → 0.1.0-rc.0  (was: 0.1.0)
premajor → 0.1.0-rc.0  (was: 0.1.0)
patch    → 0.1.0        (unchanged)
```

Note: the question of whether `premajor` should produce `1.0.0-rc.0` instead of `0.1.0-rc.0` is a pre-existing behaviour from v6 (not a v7 regression) and is tracked separately - #1603

Four regression tests added covering `prepatch`, `preminor`, `premajor` first-run prerelease identifier behaviour, plus a guard test confirming non-prerelease increments are unaffected.