### PR TITLE
ci: rebuild dist after codegen so generated PRs include bundle updates

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run codegen
         run: npm run codegen
 
+      - name: Rebuild dist and run validation
+        run: npm run all
+
       - name: Create PR if changed
         uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
## Summary

The monthly codegen workflow runs `npm run codegen`, which only updates `src/types/github.graphql.generated.ts`. It does not rebuild the bundled `dist/` files.

Because PRs created by `peter-evans/create-pull-request` don't trigger CI (the warning in the PR body itself notes this), stale `dist/` can be merged to `master` uncaught — surfacing later as "Check for clean working directory" failures on unrelated PRs that happen to rebuild dist.

This adds `npm run all` after `npm run codegen` so the auto-generated PR includes any dist/schema/test updates triggered by the new types.

## Test plan

- [ ] Trigger `Update GraphQL Codegen` via workflow_dispatch and verify the resulting PR includes any dist diffs
- [ ] Confirm `npm run all` passes with the regenerated types (it does locally on master)