### PR TITLE
fix: honor a major version-resolver label on a first release

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -4375,15 +4375,11 @@ var FindRecentMergedPullRequestsDocument = {
 //#region src/actions/drafter/lib/find-pull-requests/find-recent-merged-pull-requests.ts
 var RECENT_PR_LOOKBACK = 5;
 var findRecentMergedPullRequests = async (params) => {
-	const octokit = getOctokit();
 	const nameWithOwner = `${context.repo.owner}/${context.repo.repo}`;
-	const missingPRs = ((await executeGraphql(octokit.graphql, FindRecentMergedPullRequestsDocument, {
-		name: context.repo.repo,
-		owner: context.repo.owner,
+	const missingPRs = (await queryRecentMergedPullRequests({
 		baseRefName: params.baseRefName,
-		limit: RECENT_PR_LOOKBACK,
-		...params.fieldFlags
-	})).repository?.pullRequests.nodes ?? []).filter((pr) => {
+		fieldFlags: params.fieldFlags
+	})).filter((pr) => {
 		if (!pr?.mergeCommit?.oid) return false;
 		const prKey = `${nameWithOwner}#${pr.number}`;
 		return params.commitOids.has(pr.mergeCommit.oid) && !params.foundPrKeys.has(prKey);
@@ -4391,6 +4387,33 @@ var findRecentMergedPullRequests = async (params) => {
 	if (missingPRs.length === 0) return [];
 	info(`Found ${missingPRs.length} recently merged PR(s) missing from GraphQL index, recovering: ${missingPRs.map((pr) => `#${pr?.number}`).join(", ")}`);
 	return missingPRs.filter((pr) => pr != null);
+};
+/**
+* Collect the most recently merged pull requests targeting this repository.
+*
+* Used on a first release (no published release or tag) where there is no
+* comparison baseline to derive changes from. Without a baseline the draft
+* would otherwise carry no PRs and no labels, so its version always resolved
+* to the no-change default. Scanning the recent merged PRs lets their labels
+* drive categorisation and the version-resolver increment instead.
+*/
+var findRecentMergedPullRequestsWithoutBaseline = async (params) => {
+	const pullRequests = (await queryRecentMergedPullRequests({
+		baseRefName: params.baseRefName,
+		fieldFlags: params.fieldFlags
+	})).filter((pr) => pr != null);
+	if (pullRequests.length === 0) return [];
+	info(`No comparison baseline; scanning the ${pullRequests.length} most recently merged PR(s): ${pullRequests.map((pr) => `#${pr.number}`).join(", ")}`);
+	return pullRequests;
+};
+var queryRecentMergedPullRequests = async (params) => {
+	return (await executeGraphql(getOctokit().graphql, FindRecentMergedPullRequestsDocument, {
+		name: context.repo.repo,
+		owner: context.repo.owner,
+		baseRefName: params.baseRefName,
+		limit: RECENT_PR_LOOKBACK,
+		...params.fieldFlags
+	})).repository?.pullRequests.nodes ?? [];
 };
 //#endregion
 //#region src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
@@ -4416,9 +4439,18 @@ var findPullRequests = async (params) => {
 	let commits;
 	if (!params.lastRelease?.tag_name) {
 		warning("A previous (published) release is required to find changes");
+		const { commitish } = params.config;
 		return {
 			commits: [],
-			pullRequests: []
+			pullRequests: await findRecentMergedPullRequestsWithoutBaseline({
+				baseRefName: commitish.startsWith("refs/heads/") ? commitish.replace(/^refs\/heads\//, "") : null,
+				fieldFlags: {
+					withPullRequestBody: sharedComparisonParams.withPullRequestBody,
+					withPullRequestURL: sharedComparisonParams.withPullRequestURL,
+					withBaseRefName: sharedComparisonParams.withBaseRefName,
+					withHeadRefName: sharedComparisonParams.withHeadRefName
+				}
+			})
 		};
 	}
 	info(`Finding commits between refs/tags/${params.lastRelease.tag_name} and ${params.config.commitish}...`);

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2184,7 +2184,11 @@ var getVersionInfo = (params) => {
 			preReleaseIdentifier: config["prerelease-identifier"],
 			tagPrefix: config["tag-prefix"]
 		});
-	} else {
+	} else if (_versionKeyIncrement === "major") referenceVersion = new VersionDescriptor("0.0.0", {
+		preReleaseIdentifier: config["prerelease-identifier"],
+		tagPrefix: config["tag-prefix"]
+	});
+	else {
 		_localIncrement = "no_increment";
 		referenceVersion = new VersionDescriptor("0.1.0", {
 			preReleaseIdentifier: config["prerelease-identifier"],

--- a/src/actions/drafter/lib/build-release-payload/get-version-info.ts
+++ b/src/actions/drafter/lib/build-release-payload/get-version-info.ts
@@ -89,6 +89,14 @@ export const getVersionInfo = (params: {
           tagPrefix: config['tag-prefix'],
         },
       )
+    } else if (_versionKeyIncrement === 'major') {
+      // A major-labeled PR must win on a first release: seed from 0.0.0 and
+      // apply the major increment so $RESOLVED_VERSION = "1.0.0" rather than
+      // the 0.1.0 minor baseline (release-drafter#1630).
+      referenceVersion = new VersionDescriptor('0.0.0', {
+        preReleaseIdentifier: config['prerelease-identifier'],
+        tagPrefix: config['tag-prefix'],
+      })
     } else {
       _localIncrement = 'no_increment'
       referenceVersion = new VersionDescriptor('0.1.0', {

--- a/src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
+++ b/src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
@@ -10,7 +10,10 @@ import type { ParsedConfig } from '../../config/index.ts'
 import type { findPreviousReleases } from '../find-previous-releases/index.ts'
 import { findCommitsInComparison } from './find-commits-in-comparison.ts'
 import { findCommitsWithPathChange } from './find-commits-with-path-change.ts'
-import { findRecentMergedPullRequests } from './find-recent-merged-pull-requests.ts'
+import {
+  findRecentMergedPullRequests,
+  findRecentMergedPullRequestsWithoutBaseline,
+} from './find-recent-merged-pull-requests.ts'
 
 export const findPullRequests = async (params: {
   lastRelease: Awaited<ReturnType<typeof findPreviousReleases>>['lastRelease']
@@ -64,9 +67,28 @@ export const findPullRequests = async (params: {
 
   let commits: Awaited<ReturnType<typeof findCommitsInComparison>>
 
+  // Without a published release or tag there is no comparison baseline, so the
+  // commit-range scan cannot run. Fall back to scanning the most recently
+  // merged pull requests so their labels still drive categorisation and the
+  // version-resolver increment (e.g. a `breaking` PR can resolve to a major
+  // first release). There are no comparison commits in this mode, so the
+  // contributors list is derived solely from the recovered PRs.
   if (!params.lastRelease?.tag_name) {
     core.warning('A previous (published) release is required to find changes')
-    return { commits: [], pullRequests: [] }
+
+    const { commitish } = params.config
+    const isBranchRef = commitish.startsWith('refs/heads/')
+    const pullRequests = await findRecentMergedPullRequestsWithoutBaseline({
+      baseRefName: isBranchRef ? commitish.replace(/^refs\/heads\//, '') : null,
+      fieldFlags: {
+        withPullRequestBody: sharedComparisonParams.withPullRequestBody,
+        withPullRequestURL: sharedComparisonParams.withPullRequestURL,
+        withBaseRefName: sharedComparisonParams.withBaseRefName,
+        withHeadRefName: sharedComparisonParams.withHeadRefName,
+      },
+    })
+
+    return { commits: [], pullRequests }
   }
 
   core.info(

--- a/src/actions/drafter/lib/find-pull-requests/find-recent-merged-pull-requests.ts
+++ b/src/actions/drafter/lib/find-pull-requests/find-recent-merged-pull-requests.ts
@@ -29,22 +29,12 @@ export const findRecentMergedPullRequests = async (params: {
   foundPrKeys: Set<string>
   fieldFlags: PullRequestFieldFlags
 }): Promise<RecentMergedPullRequest[]> => {
-  const octokit = getOctokit()
   const nameWithOwner = `${context.repo.owner}/${context.repo.repo}`
 
-  const data = await executeGraphql(
-    octokit.graphql,
-    FindRecentMergedPullRequestsDocument,
-    {
-      name: context.repo.repo,
-      owner: context.repo.owner,
-      baseRefName: params.baseRefName,
-      limit: RECENT_PR_LOOKBACK,
-      ...params.fieldFlags,
-    },
-  )
-
-  const prNodes = data.repository?.pullRequests.nodes ?? []
+  const prNodes = await queryRecentMergedPullRequests({
+    baseRefName: params.baseRefName,
+    fieldFlags: params.fieldFlags,
+  })
 
   const missingPRs = prNodes.filter((pr) => {
     if (!pr?.mergeCommit?.oid) return false
@@ -62,4 +52,56 @@ export const findRecentMergedPullRequests = async (params: {
   )
 
   return missingPRs.filter((pr): pr is RecentMergedPullRequest => pr != null)
+}
+
+/**
+ * Collect the most recently merged pull requests targeting this repository.
+ *
+ * Used on a first release (no published release or tag) where there is no
+ * comparison baseline to derive changes from. Without a baseline the draft
+ * would otherwise carry no PRs and no labels, so its version always resolved
+ * to the no-change default. Scanning the recent merged PRs lets their labels
+ * drive categorisation and the version-resolver increment instead.
+ */
+export const findRecentMergedPullRequestsWithoutBaseline = async (params: {
+  baseRefName: string | null
+  fieldFlags: PullRequestFieldFlags
+}): Promise<RecentMergedPullRequest[]> => {
+  const prNodes = await queryRecentMergedPullRequests({
+    baseRefName: params.baseRefName,
+    fieldFlags: params.fieldFlags,
+  })
+
+  const pullRequests = prNodes.filter(
+    (pr): pr is RecentMergedPullRequest => pr != null,
+  )
+
+  if (pullRequests.length === 0) return []
+
+  core.info(
+    `No comparison baseline; scanning the ${pullRequests.length} most recently merged PR(s): ${pullRequests.map((pr) => `#${pr.number}`).join(', ')}`,
+  )
+
+  return pullRequests
+}
+
+const queryRecentMergedPullRequests = async (params: {
+  baseRefName: string | null
+  fieldFlags: PullRequestFieldFlags
+}) => {
+  const octokit = getOctokit()
+
+  const data = await executeGraphql(
+    octokit.graphql,
+    FindRecentMergedPullRequestsDocument,
+    {
+      name: context.repo.repo,
+      owner: context.repo.owner,
+      baseRefName: params.baseRefName,
+      limit: RECENT_PR_LOOKBACK,
+      ...params.fieldFlags,
+    },
+  )
+
+  return data.repository?.pullRequests.nodes ?? []
 }

--- a/src/tests/drafter/drafter.e2e.test.ts
+++ b/src/tests/drafter/drafter.e2e.test.ts
@@ -127,12 +127,15 @@ describe('drafter e2e', () => {
     })
 
     describe('with no past releases', () => {
-      it('inserts no comparison baseline warning, and $PREVIOUS_TAG to blank', async () => {
+      it('scans recent merged PRs, inserts the no-baseline warning, and sets $PREVIOUS_TAG to blank', async () => {
         await mockContext('push')
         mocks.config.mockReturnValue('config-previous-tag')
 
+        // Without a published baseline the comparison scan cannot run, so the
+        // recently merged PRs are queried directly to recover their changes.
         const gqlScope = mockGraphqlQuery({
-          payload: 'graphql-comparison-merge-commit',
+          query: 'query findRecentMergedPullRequests',
+          payload: 'graphql-recent-merged-prs',
         })
 
         const scope = nockGetAndPostReleases({ fetchedReleases: [] })
@@ -143,7 +146,7 @@ describe('drafter e2e', () => {
           [
             {
               "body": "Changes:
-          * No changes
+          * Add new feature (#6) @TimonVS
 
           Previous tag: ''
 
@@ -170,7 +173,35 @@ describe('drafter e2e', () => {
         `)
 
         expect(scope.isDone()).toBe(true) // should call the mocked endpoints
-        expect(gqlScope.isDone()).toBe(false) // gql not called
+        expect(gqlScope.isDone()).toBe(true) // recent merged PRs were scanned
+        expect(mocks.core.setFailed).not.toHaveBeenCalled()
+      })
+
+      it('resolves a first release to 1.0.0 when a recent merged PR carries the major version-resolver label (#1630)', async () => {
+        await mockContext('push')
+        mocks.config.mockReturnValue(
+          'config-with-version-resolver-major-and-changes',
+        )
+
+        const gqlScope = mockGraphqlQuery({
+          query: 'query findRecentMergedPullRequests',
+          payload: 'graphql-recent-merged-prs-major-label',
+        })
+
+        const scope = nockGetAndPostReleases({ fetchedReleases: [] })
+
+        await runDrafter()
+
+        const lastCall = mocks.postReleaseBody.mock.lastCall?.at(0) as
+          | { name: string; tag_name: string; body: string }
+          | undefined
+
+        expect(lastCall?.name).toBe('v1.0.0')
+        expect(lastCall?.tag_name).toBe('v1.0.0')
+        expect(lastCall?.body).toContain('Drop legacy API @TimonVS (#7)')
+
+        expect(scope.isDone()).toBe(true) // should call the mocked endpoints
+        expect(gqlScope.isDone()).toBe(true) // recent merged PRs were scanned
         expect(mocks.core.setFailed).not.toHaveBeenCalled()
       })
     })
@@ -2927,7 +2958,8 @@ describe('drafter e2e', () => {
           fetchedReleases: [],
         })
         const gqlScope = mockGraphqlQuery({
-          payload: 'graphql-comparison-empty',
+          query: 'query findRecentMergedPullRequests',
+          payload: 'graphql-recent-merged-prs-empty',
         })
         await runDrafter()
         expect(mocks.postReleaseBody.mock.lastCall).toMatchInlineSnapshot(`
@@ -2967,7 +2999,7 @@ describe('drafter e2e', () => {
           ]
         `)
         expect(scope.isDone()).toBe(true) // should call the mocked endpoints
-        expect(gqlScope.isDone()).toBe(false) // gql not called
+        expect(gqlScope.isDone()).toBe(true) // recent merged PRs were scanned
         expect(mocks.core.setFailed).not.toHaveBeenCalled()
       })
     })
@@ -3022,7 +3054,8 @@ describe('drafter e2e', () => {
           fetchedReleases: [],
         })
         const gqlScope = mockGraphqlQuery({
-          payload: 'graphql-comparison-empty',
+          query: 'query findRecentMergedPullRequests',
+          payload: 'graphql-recent-merged-prs-empty',
         })
         await runDrafter()
         expect(mocks.postReleaseBody.mock.lastCall).toMatchInlineSnapshot(`
@@ -3062,7 +3095,7 @@ describe('drafter e2e', () => {
           ]
         `)
         expect(scope.isDone()).toBe(true) // should call the mocked endpoints
-        expect(gqlScope.isDone()).toBe(false) // gql not called
+        expect(gqlScope.isDone()).toBe(true) // recent merged PRs were scanned
         expect(mocks.core.setFailed).not.toHaveBeenCalled()
       })
     })
@@ -3369,8 +3402,8 @@ describe('drafter e2e', () => {
           ],
         })
         const gqlScope = mockGraphqlQuery({
-          query: 'query findCommitsInComparison',
-          payload: 'graphql-comparison-empty',
+          query: 'query findRecentMergedPullRequests',
+          payload: 'graphql-recent-merged-prs-empty',
         })
         await runDrafter()
         expect(mocks.patchReleaseBody.mock.lastCall).toMatchInlineSnapshot(`
@@ -3400,7 +3433,7 @@ describe('drafter e2e', () => {
           ]
         `)
         expect(scope.isDone()).toBe(true) // should call the mocked endpoints
-        expect(gqlScope.isDone()).toBe(false) // gql not called
+        expect(gqlScope.isDone()).toBe(true) // recent merged PRs were scanned
         expect(mocks.core.setFailed).not.toHaveBeenCalled()
       })
     })

--- a/src/tests/drafter/get-version-info.test.ts
+++ b/src/tests/drafter/get-version-info.test.ts
@@ -285,6 +285,22 @@ describe('versions', () => {
     expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0')
   })
 
+  it('honors a major version-resolver increment on a first release (#1630)', () => {
+    // On a repo with no prior release or tag, a PR labeled to the `major`
+    // resolver should win and produce 1.0.0, not the 0.1.0 minor baseline.
+    const versionInfo = getVersionInfo({
+      lastRelease: undefined,
+      input: {},
+      config: { 'version-template': '$MAJOR.$MINOR.$PATCH$PRERELEASE' },
+      versionKeyIncrement: 'major',
+    })
+
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('1.0.0')
+    expect(versionInfo.$RESOLVED_VERSION_MAJOR).toEqual('1')
+    expect(versionInfo.$RESOLVED_VERSION_MINOR).toEqual('0')
+    expect(versionInfo.$RESOLVED_VERSION_PATCH).toEqual('0')
+  })
+
   it('applies custom version template when no previous releases exist', () => {
     const versionInfo = getVersionInfo({
       lastRelease: undefined,

--- a/src/tests/fixtures/config/config-with-version-resolver-major-and-changes.yml
+++ b/src/tests/fixtures/config/config-with-version-resolver-major-and-changes.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+branches:
+  - master
+categories:
+  - title: '🚀 Features'
+    when:
+      label: 'feature'
+  - title: '🐛 Bug fixes'
+    when:
+      label: 'bug'
+  - type: version-resolver
+    'semver-increment': major
+    when:
+      label: 'major'
+  - type: version-resolver
+    'semver-increment': minor
+    when:
+      label: 'minor'
+  - type: version-resolver
+    'semver-increment': patch
+    when:
+      label: 'patch'
+  - type: version-resolver
+    'semver-increment': minor
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/src/tests/fixtures/graphql/graphql-recent-merged-prs-empty.json
+++ b/src/tests/fixtures/graphql/graphql-recent-merged-prs-empty.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "__typename": "PullRequestConnection",
+        "nodes": []
+      }
+    }
+  }
+}

--- a/src/tests/fixtures/graphql/graphql-recent-merged-prs-major-label.json
+++ b/src/tests/fixtures/graphql/graphql-recent-merged-prs-major-label.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "__typename": "PullRequestConnection",
+        "nodes": [
+          {
+            "__typename": "PullRequest",
+            "title": "Drop legacy API",
+            "number": 7,
+            "url": "https://github.com/toolmantim/release-drafter-test-project/pull/7",
+            "body": "Removes the deprecated endpoints",
+            "author": {
+              "__typename": "User",
+              "login": "TimonVS",
+              "url": "https://github.com/TimonVS"
+            },
+            "baseRepository": {
+              "__typename": "Repository",
+              "nameWithOwner": "toolmantim/release-drafter-test-project"
+            },
+            "mergedAt": "2019-04-27T14:00:00Z",
+            "isCrossRepository": false,
+            "labels": {
+              "__typename": "LabelConnection",
+              "nodes": [
+                {
+                  "__typename": "Label",
+                  "name": "major"
+                }
+              ]
+            },
+            "merged": true,
+            "baseRefName": "master",
+            "headRefName": "drop-legacy-api",
+            "mergeCommit": {
+              "__typename": "Commit",
+              "oid": "f1e2d3c4b5a6f1e2d3c4b5a6f1e2d3c4b5a6f1e2"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/tests/mocks/config.ts
+++ b/src/tests/mocks/config.ts
@@ -66,6 +66,7 @@ export type AvailableConfigs =
   | 'config-with-sort-by-title'
   | 'config-with-sort-direction-ascending'
   | 'config-with-tag-prefix'
+  | 'config-with-version-resolver-major-and-changes'
   | 'config-with-yaml-exception'
   | 'config'
   | 'config-filter-range'

--- a/src/tests/mocks/graphql.ts
+++ b/src/tests/mocks/graphql.ts
@@ -36,6 +36,8 @@ type Payload =
   | 'graphql-include-path-missing-pr'
   | 'graphql-recent-merged-prs'
   | 'graphql-recent-merged-prs-with-paths'
+  | 'graphql-recent-merged-prs-major-label'
+  | 'graphql-recent-merged-prs-empty'
 
 export const getGqlPayload = (payload: Payload) =>
   JSON.parse(


### PR DESCRIPTION
## Summary

On a repository with no previously published release, a first release never honors a `major`
version-resolver label: a `breaking`-labeled PR drafts `v0.1.0` instead of `v1.0.0`, and on a fresh
repo the draft is empty ("No changes") even though merged PRs exist.

Fixes #1630.

## Root cause

Two compounding issues on the no-baseline (first release) path:

1. `findPullRequests` short-circuits when there is no published release/tag, returning no pull
   requests before any label is read — so the version-resolver increment always falls back to the
   default (`patch`) and the breaking PR never appears in the notes:

   ```ts
   if (!params.lastRelease?.tag_name) {
     core.warning('A previous (published) release is required to find changes')
     return { commits: [], pullRequests: [] }
   }
   ```

2. Even when the increment is `major`, `getVersionInfo` seeded the no-baseline reference at the
   hardcoded `0.1.0` and forced `no_increment`, discarding the resolved increment — so a first
   release always resolved to `0.1.0`.

## Fix

- **`get-version-info.ts`** — when there is no prior release, no version input, and the resolved
  increment is `major`, seed the reference at `0.0.0` and apply the increment so `$RESOLVED_VERSION`
  becomes `1.0.0`. The `0.1.0` minor/patch baseline and the prerelease-identifier first-run path are
  unchanged.
- **`find-pull-requests.ts`** — on the no-baseline path, instead of returning empty, scan the most
  recently merged pull requests so their labels drive categorization and version resolution. The
  warning banner is unchanged.
- **`find-recent-merged-pull-requests.ts`** — extracted the shared GraphQL query into a helper; the
  existing lagging-index recovery (`findRecentMergedPullRequests`) is behavior-identical; added
  `findRecentMergedPullRequestsWithoutBaseline`, which returns recent merged PRs without the
  commit-OID intersection (there are no comparison commits on a first release).

Result: a `breaking` PR on a fresh repo resolves to `major` -> `v1.0.0`, with the PR listed.

## Tests

- Updated the "no past releases" e2e tests (which previously asserted the short-circuit: no PR query,
  "No changes") to assert that recent merged PRs are now scanned.
- Added an e2e test: no baseline + a `major`-resolver-labeled merged PR -> drafted `v1.0.0` with the
  PR listed (new config + GraphQL fixtures).
- Added a `getVersionInfo` unit test for the major-first-release case.
- `npm run all` (lint, typecheck, full suite, schema, build) passes; the committed `dist/` is rebuilt.

## Notes

- The extra recent-merged-PR query runs **only** when there is no published baseline (bounded by
  `RECENT_PR_LOOKBACK`); steady-state runs are unaffected.
- The lookback scans the most recently updated merged PRs, so a large first-release backlog could
  exceed the window; this reuses the existing recovery constant rather than introducing a new one.
- On a first release there are no comparison commits, so path-based pre-include/pre-exclude
  conditions are inert (`matchedPaths` is empty); label-based categorization and version resolution
  are unaffected.
