### PR TITLE
feat: align increments to semver lib from 0.0.0

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2176,21 +2176,21 @@ var getVersionInfo = (params) => {
 		_localIncrement = "no_increment";
 		referenceVersion = versionFromInput;
 	} else if (versionFromLastRelease.version) {
-		_localIncrement = _localIncrement?.startsWith("pre") && versionFromLastRelease?.prerelease?.length ? "prerelease" : _localIncrement;
 		referenceVersion = versionFromLastRelease;
-	} else if (_versionKeyIncrement?.startsWith("pre") && config["prerelease-identifier"]) {
-		_localIncrement = "no_increment";
-		referenceVersion = new VersionDescriptor(`0.1.0-${config["prerelease-identifier"]}.0`, {
-			preReleaseIdentifier: config["prerelease-identifier"],
-			tagPrefix: config["tag-prefix"]
-		});
-	} else {
-		_localIncrement = "no_increment";
-		referenceVersion = new VersionDescriptor("0.1.0", {
-			preReleaseIdentifier: config["prerelease-identifier"],
-			tagPrefix: config["tag-prefix"]
-		});
-	}
+		const incrementsToPrerelease = _localIncrement?.startsWith("pre");
+		const lastReleaseIsPrerelease = referenceVersion?.prerelease?.length;
+		if (incrementsToPrerelease) {
+			if (lastReleaseIsPrerelease) {
+				if (_localIncrement !== "prerelease") {
+					info(`versionKeyIncrement is set to "${_localIncrement}", but the last release is already a prerelease (${referenceVersion.version?.format() || "none"}). The version will be incremented as a prerelease instead.`);
+					_localIncrement = "prerelease";
+				}
+			}
+		}
+	} else referenceVersion = new VersionDescriptor("0.0.0", {
+		preReleaseIdentifier: config["prerelease-identifier"],
+		tagPrefix: config["tag-prefix"]
+	});
 	return {
 		$NEXT_MAJOR_VERSION: referenceVersion.incremented("major").rendered(config["version-template"]),
 		$NEXT_MAJOR_VERSION_MAJOR: referenceVersion.incremented("major").major,

--- a/src/actions/drafter/lib/build-release-payload/get-version-info.ts
+++ b/src/actions/drafter/lib/build-release-payload/get-version-info.ts
@@ -59,15 +59,35 @@ export const getVersionInfo = (params: {
 
   let referenceVersion: VersionDescriptor
   if (versionFromInput.version) {
+    // Use version input
     _localIncrement = 'no_increment' // use that exact input version
     referenceVersion = versionFromInput
   } else if (versionFromLastRelease.version) {
-    _localIncrement =
-      _localIncrement?.startsWith('pre') &&
-      versionFromLastRelease?.prerelease?.length
-        ? 'prerelease'
-        : _localIncrement
+    // Use previous published release
     referenceVersion = versionFromLastRelease
+
+    // Handle prereleases
+    const incrementsToPrerelease = _localIncrement?.startsWith('pre')
+    const lastReleaseIsPrerelease = referenceVersion?.prerelease?.length
+    if (incrementsToPrerelease) {
+      if (lastReleaseIsPrerelease) {
+        // Set local increment to 'prerelease', so that we simply
+        // increment the prerelease number (e.g., 1.2.3-beta.6 -> 1.2.3-beta.7).
+        // When publishing prerelease releases, the first published prerelease is supposed to set
+        // the stage for the semver increment (e.g. 1.2.2 --(prepatch)--> 1.2.3-beta.0).
+        // Subsequent prerelease increments should only increment the prerelease number (e.g. 1.2.3-beta.0 --(prerelease)--> 1.2.3-beta.1).
+        // The following increments are considered invalid :
+        //    - 1.2.3-beta.1 --(prepatch)--> ??????
+        //    - 1.2.3-beta.1 --(preminor)--> ??????
+        //    - 1.2.3-beta.1 --(premajor)--> ??????
+        if (_localIncrement !== 'prerelease') {
+          core.info(
+            `versionKeyIncrement is set to "${_localIncrement}", but the last release is already a prerelease (${referenceVersion.version?.format() || 'none'}). The version will be incremented as a prerelease instead.`,
+          )
+          _localIncrement = 'prerelease'
+        }
+      }
+    }
   } else {
     // No prior release and no input version: start from 0.1.0.
     // For prerelease-based increments (prepatch/preminor/premajor) with a

--- a/src/actions/drafter/lib/build-release-payload/get-version-info.ts
+++ b/src/actions/drafter/lib/build-release-payload/get-version-info.ts
@@ -89,33 +89,11 @@ export const getVersionInfo = (params: {
       }
     }
   } else {
-    // No prior release and no input version: start from 0.1.0.
-    // For prerelease-based increments (prepatch/preminor/premajor) with a
-    // prerelease-identifier, build the reference as "0.1.0-<identifier>.0" and
-    // use no_increment, so $RESOLVED_VERSION = "0.1.0-rc.0" — a prerelease *of*
-    // the initial version rather than a prerelease of the next incremented
-    // version (which semver's prepatch/preminor/premajor would otherwise
-    // produce, e.g. "0.1.1-rc.0").  This restores the v6 behaviour introduced
-    // in PR #1303.
-    if (
-      _versionKeyIncrement?.startsWith('pre') &&
-      config['prerelease-identifier']
-    ) {
-      _localIncrement = 'no_increment'
-      referenceVersion = new VersionDescriptor(
-        `0.1.0-${config['prerelease-identifier']}.0`,
-        {
-          preReleaseIdentifier: config['prerelease-identifier'],
-          tagPrefix: config['tag-prefix'],
-        },
-      )
-    } else {
-      _localIncrement = 'no_increment'
-      referenceVersion = new VersionDescriptor('0.1.0', {
-        preReleaseIdentifier: config['prerelease-identifier'],
-        tagPrefix: config['tag-prefix'],
-      })
-    }
+    // No previous release and no input version
+    referenceVersion = new VersionDescriptor('0.0.0', {
+      preReleaseIdentifier: config['prerelease-identifier'],
+      tagPrefix: config['tag-prefix'],
+    })
   }
 
   return {

--- a/src/tests/drafter/drafter.e2e.test.ts
+++ b/src/tests/drafter/drafter.e2e.test.ts
@@ -3054,9 +3054,9 @@ describe('drafter e2e', () => {
           ",
               "draft": true,
               "make_latest": "true",
-              "name": "v0.1.0 🌈",
+              "name": "v0.0.1 🌈",
               "prerelease": false,
-              "tag_name": "v0.1.0",
+              "tag_name": "v0.0.1",
               "target_commitish": "refs/heads/master",
             },
           ]

--- a/src/tests/drafter/get-version-info.test.ts
+++ b/src/tests/drafter/get-version-info.test.ts
@@ -200,20 +200,20 @@ describe('versions', () => {
         "$NEXT_MAJOR_VERSION_MAJOR": "1",
         "$NEXT_MAJOR_VERSION_MINOR": "0",
         "$NEXT_MAJOR_VERSION_PATCH": "0",
-        "$NEXT_MINOR_VERSION": "0.2.0",
+        "$NEXT_MINOR_VERSION": "0.1.0",
         "$NEXT_MINOR_VERSION_MAJOR": "0",
-        "$NEXT_MINOR_VERSION_MINOR": "2",
+        "$NEXT_MINOR_VERSION_MINOR": "1",
         "$NEXT_MINOR_VERSION_PATCH": "0",
-        "$NEXT_PATCH_VERSION": "0.1.1",
+        "$NEXT_PATCH_VERSION": "0.0.1",
         "$NEXT_PATCH_VERSION_MAJOR": "0",
-        "$NEXT_PATCH_VERSION_MINOR": "1",
+        "$NEXT_PATCH_VERSION_MINOR": "0",
         "$NEXT_PATCH_VERSION_PATCH": "1",
-        "$NEXT_PRERELEASE_VERSION": "0.1.1-0",
+        "$NEXT_PRERELEASE_VERSION": "0.0.1-0",
         "$NEXT_PRERELEASE_VERSION_PRERELEASE": "-0",
-        "$RESOLVED_VERSION": "0.1.0",
+        "$RESOLVED_VERSION": "0.0.1",
         "$RESOLVED_VERSION_MAJOR": "0",
-        "$RESOLVED_VERSION_MINOR": "1",
-        "$RESOLVED_VERSION_PATCH": "0",
+        "$RESOLVED_VERSION_MINOR": "0",
+        "$RESOLVED_VERSION_PATCH": "1",
         "$RESOLVED_VERSION_PRERELEASE": "",
       }
     `,
@@ -221,12 +221,6 @@ describe('versions', () => {
   })
 
   it('uses prerelease-identifier on first run when versionKeyIncrement is prerelease-based', () => {
-    // Regression test: v7 broke v6 behaviour (PR #1303) where first-run with a
-    // prerelease-identifier set produced a bare version (e.g. "0.1.0") instead
-    // of a prerelease of the initial version (e.g. "0.1.0-rc.0").
-    // semver's prepatch would normally give "0.1.1-rc.0" (increments patch
-    // before adding the prerelease suffix), but on first run there is no prior
-    // release to increment from, so the result should be "0.1.0-rc.0".
     const versionInfo = getVersionInfo({
       lastRelease: undefined,
       input: {},
@@ -237,7 +231,7 @@ describe('versions', () => {
       versionKeyIncrement: 'prepatch',
     })
 
-    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0-rc.0')
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.0.1-rc.0')
     expect(versionInfo.$RESOLVED_VERSION_PRERELEASE).toEqual('-rc.0')
   })
 
@@ -267,11 +261,11 @@ describe('versions', () => {
       versionKeyIncrement: 'premajor',
     })
 
-    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0-rc.0')
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('1.0.0-rc.0')
     expect(versionInfo.$RESOLVED_VERSION_PRERELEASE).toEqual('-rc.0')
   })
 
-  it('still returns bare 0.1.0 on first run when versionKeyIncrement is not prerelease-based', () => {
+  it('still returns bare 0.0.1 on first run when versionKeyIncrement is not prerelease-based', () => {
     const versionInfo = getVersionInfo({
       lastRelease: undefined,
       input: {},
@@ -282,7 +276,7 @@ describe('versions', () => {
       versionKeyIncrement: 'patch',
     })
 
-    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1.0')
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.0.1')
   })
 
   it('applies custom version template when no previous releases exist', () => {
@@ -294,8 +288,7 @@ describe('versions', () => {
     })
 
     expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1')
-    // $NEXT_MINOR_VERSION should increment from 0.1.0 to 0.2.0, so formatted as "0.2"
-    expect(versionInfo.$NEXT_MINOR_VERSION).toEqual('0.2')
+    expect(versionInfo.$NEXT_MINOR_VERSION).toEqual('0.1')
   })
 
   it('supports version template with only MINOR.PATCH format', () => {
@@ -306,11 +299,9 @@ describe('versions', () => {
       versionKeyIncrement: 'patch',
     })
 
-    expect(versionInfo.$RESOLVED_VERSION).toEqual('1.0')
-    // $NEXT_PATCH_VERSION should increment from 0.1.0 to 0.1.1, so formatted as "1.1"
-    expect(versionInfo.$NEXT_PATCH_VERSION).toEqual('1.1')
-    // $NEXT_MINOR_VERSION should increment from 0.1.0 to 0.2.0, so formatted as "2.0"
-    expect(versionInfo.$NEXT_MINOR_VERSION).toEqual('2.0')
+    expect(versionInfo.$RESOLVED_VERSION).toEqual('0.1')
+    expect(versionInfo.$NEXT_PATCH_VERSION).toEqual('0.1')
+    expect(versionInfo.$NEXT_MINOR_VERSION).toEqual('1.0')
   })
 
   it('supports hardcoded major with 1.MINOR.PATCH format with existing releases', () => {


### PR DESCRIPTION

fix #1603
supersedes #1628 

## Summary

Align version increment behavior with semver semantics when no previous release exists (baseline `0.0.0`), especially for prerelease flows.

This change ensures the first computed release version follows semver-consistent increments and that prerelease identifiers are applied correctly from the very first run.

## What changed

- Updated version resolution in `getVersionInfo` to use a `0.0.0` reference baseline when there is no prior release and no explicit version/tag/name input.prerelease).
- Updated test expectations accordingly.

## Why

Previously, initial version derivation from an empty release history could diverge from semver-native increment semantics in prerelease scenarios.

By anchoring first-run calculations on `0.0.0`, release resolution is predictable and consistent with semver behavior across:

- normal increments (`patch`/`minor`/`major`)
- prerelease increments (`prepatch`/`preminor`/`premajor`)
- custom prerelease identifiers.

## Impact

- **Behavioral change (first run only):** repositories without any published release now get semver-consistent prerelease increment outcomes.
- **No regression expected** for repositories with existing releases or for explicit input-driven versions.

