### PR TITLE
fix: require actual matches for category mode `only`

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -1509,7 +1509,7 @@ var matchesValues = (actualValues, expectedValues, mode) => {
 	if (expected.length === 0) return true;
 	switch (mode) {
 		case "all": return expected.every((value) => actual.includes(value));
-		case "only": return actual.every((value) => expected.includes(value));
+		case "only": return actual.length > 0 && actual.every((value) => expected.includes(value));
 		case "exactly": return actual.length === expected.length && actual.every((value) => expected.includes(value));
 		default: return expected.length === 0 || expected.some((value) => actual.includes(value));
 	}

--- a/src/actions/drafter/common/category-matching.ts
+++ b/src/actions/drafter/common/category-matching.ts
@@ -43,7 +43,11 @@ const matchesValues = (
     case 'all':
       return expected.every((value) => actual.includes(value))
     case 'only':
-      return actual.every((value) => expected.includes(value))
+      // An empty matched set vacuously passes `every`, but `only` should still
+      // require at least one configured match before the condition counts.
+      return (
+        actual.length > 0 && actual.every((value) => expected.includes(value))
+      )
     case 'exactly':
       return (
         actual.length === expected.length &&

--- a/src/tests/drafter/category-model.test.ts
+++ b/src/tests/drafter/category-model.test.ts
@@ -334,6 +334,44 @@ describe('category model', () => {
     ).toBe(false)
   })
 
+  it('does not treat empty labels or paths as a match for mode only', () => {
+    const labelsOnlyConfig = makeParsedConfig([
+      {
+        title: 'Features',
+        when: {
+          labels: ['feature', 'enhancement'],
+          'labels-mode': 'only',
+        },
+      },
+    ])
+    const pathsOnlyConfig = makeParsedConfig([
+      {
+        title: 'Source and docs changes',
+        when: {
+          paths: ['src/**', 'docs/**'],
+          'paths-mode': 'only',
+        },
+      },
+    ])
+
+    const labelsOnlyCondition = labelsOnlyConfig.categories[0]?.when[0]
+    const pathsOnlyCondition = pathsOnlyConfig.categories[0]?.when[0]
+
+    expect(labelsOnlyCondition).toBeDefined()
+    expect(pathsOnlyCondition).toBeDefined()
+
+    if (!labelsOnlyCondition || !pathsOnlyCondition) {
+      throw new Error('Expected normalized category conditions')
+    }
+
+    expect(
+      matchesCategoryCondition(labelsOnlyCondition, makePullRequest([])),
+    ).toBe(false)
+    expect(
+      matchesCategoryCondition(pathsOnlyCondition, makePullRequest([], [])),
+    ).toBe(false)
+  })
+
   it('only prefilters pre-exclude paths for paths-mode any', () => {
     const config = makeParsedConfig([
       {


### PR DESCRIPTION
fix #1638 