### PR TITLE
fix: duplicate and skipped release contributors

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2002,6 +2002,8 @@ var generateContributorsSentence = (params) => {
 		});
 	}
 	const sortedContributors = [...contributors.values()].filter((contributor) => "name" in contributor || !config["exclude-contributors"].some((excluded) => excluded === contributor.login || `${excluded}${botSuffix}` === contributor.login)).sort((a, b) => {
+		const aIsBot = "login" in a && a.botUrl !== void 0;
+		if (aIsBot !== ("login" in b && b.botUrl !== void 0)) return aIsBot ? 1 : -1;
 		const aName = "name" in a ? a.name : a.login;
 		const bName = "name" in b ? b.name : b.login;
 		return aName.localeCompare(bName);

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -1978,18 +1978,34 @@ var generateChangeLog = (params) => {
 };
 //#endregion
 //#region src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+var botSuffix = "[bot]";
+var pullRequestKey = (pullRequest) => `${pullRequest.baseRepository?.nameWithOwner}#${pullRequest.number}`;
+var normalizeLogin = (login, isBot = false) => isBot && !login.endsWith(botSuffix) ? `${login}${botSuffix}` : login;
 var generateContributorsSentence = (params) => {
 	const { commits, pullRequests, config } = params;
-	const contributors = /* @__PURE__ */ new Set();
+	const includedPullRequests = filterPullRequestsByPreCategories(pullRequests, config.categories);
+	const includedPullRequestKeys = new Set(includedPullRequests.map(pullRequestKey));
+	const contributors = /* @__PURE__ */ new Map();
 	for (const commit of commits) {
-		if ((commit.associatedPullRequests?.nodes?.length ?? 0) === 0) continue;
+		if (!commit.associatedPullRequests?.nodes?.some((pullRequest) => pullRequest && includedPullRequestKeys.has(pullRequestKey(pullRequest)))) continue;
 		if (commit.author?.user) {
-			if (!config["exclude-contributors"].includes(commit.author.user.login)) contributors.add(`@${commit.author.user.login}`);
-		} else if (commit.author?.name) contributors.add(commit.author.name);
+			const login = normalizeLogin(commit.author.user.login);
+			contributors.set(`login:${login}`, { login });
+		} else if (commit.author?.name) contributors.set(`name:${commit.author.name}`, { name: commit.author.name });
 	}
-	for (const pullRequest of pullRequests) if (pullRequest.author && !config["exclude-contributors"].includes(pullRequest.author.login)) if (pullRequest.author.__typename === "Bot") contributors.add(`[${pullRequest.author.login}[bot]](${pullRequest.author.url})`);
-	else contributors.add(`@${pullRequest.author.login}`);
-	const sortedContributors = [...contributors].sort();
+	for (const pullRequest of includedPullRequests) if (pullRequest.author) {
+		const isBot = pullRequest.author.__typename === "Bot";
+		const login = normalizeLogin(pullRequest.author.login, isBot);
+		contributors.set(`login:${login}`, {
+			login,
+			botUrl: isBot ? pullRequest.author.url : void 0
+		});
+	}
+	const sortedContributors = [...contributors.values()].filter((contributor) => "name" in contributor || !config["exclude-contributors"].some((excluded) => excluded === contributor.login || `${excluded}${botSuffix}` === contributor.login)).map((contributor) => {
+		if ("name" in contributor) return contributor.name;
+		if (contributor.botUrl) return `[@${contributor.login}](${contributor.botUrl})`;
+		return contributor.login.endsWith(botSuffix) ? contributor.login : `@${contributor.login}`;
+	}).sort();
 	if (sortedContributors.length > 1) return sortedContributors.slice(0, -1).join(", ") + " and " + sortedContributors.slice(-1);
 	else if (sortedContributors.length === 1) return sortedContributors[0];
 	else return config["no-contributors-template"];

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2001,11 +2001,15 @@ var generateContributorsSentence = (params) => {
 			botUrl: isBot ? pullRequest.author.url : void 0
 		});
 	}
-	const sortedContributors = [...contributors.values()].filter((contributor) => "name" in contributor || !config["exclude-contributors"].some((excluded) => excluded === contributor.login || `${excluded}${botSuffix}` === contributor.login)).map((contributor) => {
+	const sortedContributors = [...contributors.values()].filter((contributor) => "name" in contributor || !config["exclude-contributors"].some((excluded) => excluded === contributor.login || `${excluded}${botSuffix}` === contributor.login)).sort((a, b) => {
+		const aName = "name" in a ? a.name : a.login;
+		const bName = "name" in b ? b.name : b.login;
+		return aName.localeCompare(bName);
+	}).map((contributor) => {
 		if ("name" in contributor) return contributor.name;
 		if (contributor.botUrl) return `[@${contributor.login}](${contributor.botUrl})`;
 		return contributor.login.endsWith(botSuffix) ? contributor.login : `@${contributor.login}`;
-	}).sort();
+	});
 	if (sortedContributors.length > 1) return sortedContributors.slice(0, -1).join(", ") + " and " + sortedContributors.slice(-1);
 	else if (sortedContributors.length === 1) return sortedContributors[0];
 	else return config["no-contributors-template"];

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -1,44 +1,92 @@
-import type { Config } from '../../config/index.ts'
+import { filterPullRequestsByPreCategories } from '../../common/category-matching.ts'
+import type { ParsedConfig } from '../../config/index.ts'
 import type { findPullRequests } from '../find-pull-requests/index.ts'
+
+type PullRequest = Awaited<
+  ReturnType<typeof findPullRequests>
+>['pullRequests'][number]
+
+type Contributor = { login: string; botUrl?: string } | { name: string }
+
+const botSuffix = '[bot]'
+const pullRequestKey = (pullRequest: PullRequest) =>
+  `${pullRequest.baseRepository?.nameWithOwner}#${pullRequest.number}`
+const normalizeLogin = (login: string, isBot = false) =>
+  isBot && !login.endsWith(botSuffix) ? `${login}${botSuffix}` : login
 
 export const generateContributorsSentence = (params: {
   commits: Awaited<ReturnType<typeof findPullRequests>>['commits']
   pullRequests: Awaited<ReturnType<typeof findPullRequests>>['pullRequests']
-  config: Pick<Config, 'exclude-contributors' | 'no-contributors-template'>
+  config: Pick<
+    ParsedConfig,
+    'categories' | 'exclude-contributors' | 'no-contributors-template'
+  >
 }) => {
   const { commits, pullRequests, config } = params
 
-  const contributors = new Set<string>()
+  const includedPullRequests = filterPullRequestsByPreCategories(
+    pullRequests,
+    config.categories,
+  )
+  const includedPullRequestKeys = new Set(
+    includedPullRequests.map(pullRequestKey),
+  )
+  const contributors = new Map<string, Contributor>()
 
   // Add from commits that have associated pull requests
   for (const commit of commits) {
-    if ((commit.associatedPullRequests?.nodes?.length ?? 0) === 0) continue
+    if (
+      !commit.associatedPullRequests?.nodes?.some(
+        (pullRequest) =>
+          pullRequest &&
+          includedPullRequestKeys.has(pullRequestKey(pullRequest)),
+      )
+    ) {
+      continue
+    }
+
     if (commit.author?.user) {
-      if (!config['exclude-contributors'].includes(commit.author.user.login)) {
-        contributors.add(`@${commit.author.user.login}`)
-      }
+      const login = normalizeLogin(commit.author.user.login)
+      contributors.set(`login:${login}`, { login })
     } else if (commit.author?.name) {
-      contributors.add(commit.author.name)
+      contributors.set(`name:${commit.author.name}`, {
+        name: commit.author.name,
+      })
     }
   }
 
   // Add from pull requests
-  for (const pullRequest of pullRequests) {
-    if (
-      pullRequest.author &&
-      !config['exclude-contributors'].includes(pullRequest.author.login)
-    ) {
-      if (pullRequest.author.__typename === 'Bot') {
-        contributors.add(
-          `[${pullRequest.author.login}[bot]](${pullRequest.author.url})`,
-        )
-      } else {
-        contributors.add(`@${pullRequest.author.login}`)
-      }
+  for (const pullRequest of includedPullRequests) {
+    if (pullRequest.author) {
+      const isBot = pullRequest.author.__typename === 'Bot'
+      const login = normalizeLogin(pullRequest.author.login, isBot)
+      contributors.set(`login:${login}`, {
+        login,
+        botUrl: isBot ? pullRequest.author.url : undefined,
+      })
     }
   }
 
-  const sortedContributors = [...contributors].sort()
+  const sortedContributors = [...contributors.values()]
+    .filter(
+      (contributor) =>
+        'name' in contributor ||
+        !config['exclude-contributors'].some(
+          (excluded) =>
+            excluded === contributor.login ||
+            `${excluded}${botSuffix}` === contributor.login,
+        ),
+    )
+    .map((contributor) => {
+      if ('name' in contributor) return contributor.name
+      if (contributor.botUrl) {
+        return `[@${contributor.login}](${contributor.botUrl})`
+      }
+      return contributor.login.endsWith(botSuffix)
+        ? contributor.login
+        : `@${contributor.login}`
+    })
+    .sort()
   if (sortedContributors.length > 1) {
     return (
       sortedContributors.slice(0, -1).join(', ') +

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -78,6 +78,10 @@ export const generateContributorsSentence = (params: {
         ),
     )
     .sort((a, b) => {
+      const aIsBot = 'login' in a && a.botUrl !== undefined
+      const bIsBot = 'login' in b && b.botUrl !== undefined
+      if (aIsBot !== bIsBot) return aIsBot ? 1 : -1
+
       const aName = 'name' in a ? a.name : a.login
       const bName = 'name' in b ? b.name : b.login
       return aName.localeCompare(bName)

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -77,6 +77,11 @@ export const generateContributorsSentence = (params: {
             `${excluded}${botSuffix}` === contributor.login,
         ),
     )
+    .sort((a, b) => {
+      const aName = 'name' in a ? a.name : a.login
+      const bName = 'name' in b ? b.name : b.login
+      return aName.localeCompare(bName)
+    })
     .map((contributor) => {
       if ('name' in contributor) return contributor.name
       if (contributor.botUrl) {
@@ -86,7 +91,6 @@ export const generateContributorsSentence = (params: {
         ? contributor.login
         : `@${contributor.login}`
     })
-    .sort()
   if (sortedContributors.length > 1) {
     return (
       sortedContributors.slice(0, -1).join(', ') +

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -662,7 +662,7 @@ describe('generate contributors sentence', () => {
         config,
       }),
     ).toBe(
-      '[@dependabot[bot]](https://github.com/apps/dependabot) and @jetersen',
+      '@jetersen and [@dependabot[bot]](https://github.com/apps/dependabot)',
     )
   })
 

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -666,6 +666,42 @@ describe('generate contributors sentence', () => {
     )
   })
 
+  it('sorts users before bots regardless of pull request order', () => {
+    const renovatePullRequest = {
+      ...botPullRequest,
+      number: 10,
+      author: {
+        __typename: 'Bot' as const,
+        login: 'renovate',
+        url: 'https://github.com/apps/renovate',
+      },
+    }
+    const cchanchePullRequest = {
+      ...userPullRequest,
+      number: 11,
+      author: {
+        __typename: 'User' as const,
+        login: 'cchanche',
+        url: 'https://github.com/cchanche',
+      },
+    }
+
+    expect(
+      generateContributorsSentence({
+        commits: [],
+        pullRequests: [
+          renovatePullRequest,
+          userPullRequest,
+          botPullRequest,
+          cchanchePullRequest,
+        ],
+        config,
+      }),
+    ).toBe(
+      '@cchanche, @jetersen, [@dependabot[bot]](https://github.com/apps/dependabot) and [@renovate[bot]](https://github.com/apps/renovate)',
+    )
+  })
+
   it('renders deleted users as @ghost', () => {
     expect(
       generateContributorsSentence({

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -631,6 +631,8 @@ describe('generate contributors sentence', () => {
 
   const botPullRequest = pullRequests.at(-1)
   if (!botPullRequest) throw new Error('Missing bot pull request fixture')
+  const userPullRequest = pullRequests.at(0)
+  if (!userPullRequest) throw new Error('Missing user pull request fixture')
   const botCommit = {
     __typename: 'Commit',
     id: 'commit-id',
@@ -652,10 +654,10 @@ describe('generate contributors sentence', () => {
     expect(
       generateContributorsSentence({
         commits: [botCommit],
-        pullRequests: [botPullRequest],
+        pullRequests: [userPullRequest, botPullRequest],
         config,
       }),
-    ).toBe('[@dependabot[bot]](https://github.com/apps/dependabot)')
+    ).toBe('[@dependabot[bot]](https://github.com/apps/dependabot) and @ghost')
   })
 
   it('excludes contributors whose pull requests are excluded', () => {

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -631,7 +631,11 @@ describe('generate contributors sentence', () => {
 
   const botPullRequest = pullRequests.at(-1)
   if (!botPullRequest) throw new Error('Missing bot pull request fixture')
-  const userPullRequest = pullRequests.at(0)
+  const ghostPullRequest = pullRequests.at(0)
+  if (!ghostPullRequest) throw new Error('Missing ghost pull request fixture')
+  const userPullRequest = pullRequests.find(
+    (pullRequest) => pullRequest.author?.login === 'jetersen',
+  )
   if (!userPullRequest) throw new Error('Missing user pull request fixture')
   const botCommit = {
     __typename: 'Commit',
@@ -657,7 +661,19 @@ describe('generate contributors sentence', () => {
         pullRequests: [userPullRequest, botPullRequest],
         config,
       }),
-    ).toBe('[@dependabot[bot]](https://github.com/apps/dependabot) and @ghost')
+    ).toBe(
+      '[@dependabot[bot]](https://github.com/apps/dependabot) and @jetersen',
+    )
+  })
+
+  it('renders deleted users as @ghost', () => {
+    expect(
+      generateContributorsSentence({
+        commits: [],
+        pullRequests: [ghostPullRequest],
+        config,
+      }),
+    ).toBe('@ghost')
   })
 
   it('excludes contributors whose pull requests are excluded', () => {

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -5,6 +5,7 @@ import {
   mergeInputAndConfig,
 } from '#src/actions/drafter/config/index.ts'
 import { generateChangeLog } from '#src/actions/drafter/lib/build-release-payload/generate-changelog.ts'
+import { generateContributorsSentence } from '#src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts'
 import { buildReleasePayload } from '#src/actions/drafter/lib/index.ts'
 import { mockContext, mocks as sharedMocks } from '#tests/mocks/index.ts'
 
@@ -616,3 +617,78 @@ const pullRequests: Parameters<typeof buildReleasePayload>[0]['pullRequests'] =
       },
     },
   ]
+
+describe('generate contributors sentence', () => {
+  let config: ReturnType<typeof mergeInputAndConfig>
+
+  beforeEach(async () => {
+    await mockContext('push')
+    config = mergeInputAndConfig({
+      config: configSchema.parse({ template: '$CONTRIBUTORS' }),
+      input: actionInputSchema.parse({ token: 'test' }),
+    })
+  })
+
+  const botPullRequest = pullRequests.at(-1)
+  if (!botPullRequest) throw new Error('Missing bot pull request fixture')
+  const botCommit = {
+    __typename: 'Commit',
+    id: 'commit-id',
+    oid: 'commit-oid',
+    committedDate: '2024-01-01T00:00:00Z',
+    message: 'Update dependencies',
+    author: {
+      __typename: 'GitActor',
+      name: 'dependabot[bot]',
+      user: { __typename: 'User', login: 'dependabot[bot]' },
+    },
+    associatedPullRequests: {
+      __typename: 'PullRequestConnection',
+      nodes: [botPullRequest],
+    },
+  } as Parameters<typeof generateContributorsSentence>[0]['commits'][number]
+
+  it('normalizes and deduplicates bot contributors before rendering', () => {
+    expect(
+      generateContributorsSentence({
+        commits: [botCommit],
+        pullRequests: [botPullRequest],
+        config,
+      }),
+    ).toBe('[@dependabot[bot]](https://github.com/apps/dependabot)')
+  })
+
+  it('excludes contributors whose pull requests are excluded', () => {
+    const skippedPullRequest = {
+      ...botPullRequest,
+      labels: {
+        __typename: 'LabelConnection' as const,
+        nodes: [{ __typename: 'Label' as const, name: 'skip-changelog' }],
+      },
+    }
+    const skippedCommit = {
+      ...botCommit,
+      associatedPullRequests: {
+        __typename: 'PullRequestConnection' as const,
+        nodes: [skippedPullRequest],
+      },
+    }
+    const skipConfig = mergeInputAndConfig({
+      config: configSchema.parse({
+        template: '$CONTRIBUTORS',
+        categories: [
+          { type: 'pre-exclude', when: { label: 'skip-changelog' } },
+        ],
+      }),
+      input: actionInputSchema.parse({ token: 'test' }),
+    })
+
+    expect(
+      generateContributorsSentence({
+        commits: [skippedCommit],
+        pullRequests: [skippedPullRequest],
+        config: skipConfig,
+      }),
+    ).toBe('No contributors')
+  })
+})


### PR DESCRIPTION
## Summary

- Normalize contributor identities before rendering so bot commit and PR variants are deduplicated.
- Include contributors only when their pull requests are included in the changelog.
- Render bot contributors as safe links and update the bundled action.

## Dependencies

None.

## Testing

- npm run all

Fixes #1424
Fixes #569

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate and skipped contributors in release notes generation
> - Fixes contributor deduplication in [`generateContributorsSentence`](https://github.com/release-drafter/release-drafter/pull/1644/files#diff-bb9ffcc9a62f8d35d98da8fca788d46992a1d58794f4962cb2044b144344d10c) by switching from a `Set` of strings to a `Map` keyed by normalized identity, preventing the same author appearing multiple times.
> - Fixes skipped contributors by filtering included PRs through pre-category exclusion before collecting authors, so contributors whose PRs fall into excluded categories are correctly omitted.
> - Normalizes bot logins by appending `[bot]` where appropriate and renders them as `[@login](url)` links; humans are sorted before bots, with both groups sorted alphabetically.
> - Adds a test suite in [`build-release-payload.test.ts`](https://github.com/release-drafter/release-drafter/pull/1644/files#diff-a0a4c5fd4af55dd9fe920d27d02ffce39870c856550e226892ca829c9ba2a556) covering bot normalization, deduplication, sorting, ghost users, and pre-category exclusion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97fa987.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->