### PR TITLE
feat: add new contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,14 @@ You can configure Release Drafter using the following key in your
 You can use any of the following variables in your `template`, `header` and
 `footer`:
 
-| Variable        | Description                                                                                                           |
-| --------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `$CHANGES`      | The markdown list of pull requests that have been merged.                                                             |
-| `$CONTRIBUTORS` | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
-| `$PREVIOUS_TAG` | The previous releases’s tag.                                                                                          |
-| `$REPOSITORY`   | Current Repository                                                                                                    |
-| `$OWNER`        | Current Repository Owner                                                                                              |
+| Variable            | Description                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `$CHANGES`          | The markdown list of pull requests that have been merged.                                                             |
+| `$CONTRIBUTORS`     | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
+| `$NEW_CONTRIBUTORS` | A Markdown section listing pull request authors making their first contribution and the corresponding pull request.  |
+| `$PREVIOUS_TAG`     | The previous releases’s tag.                                                                                          |
+| `$REPOSITORY`       | Current Repository                                                                                                    |
+| `$OWNER`            | Current Repository Owner                                                                                              |
 
 ## Category Template Variables
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can configure Release Drafter using the following key in your
 | `no-changes-template`      | Optional | The template to use for when there’s no changes. Default: `"* No changes"`.                                                                                                                                                                              |
 | `categories`               | Optional | Define how changes are filtered, grouped, and versioned. Categories support `type`, `when`, `exclusive`, `collapse-after`, and `semver-increment`. Refer to [Categorize Changes](#categorize-changes).                                                   |
 | `exclude-contributors`     | Optional | Exclude specific usernames from the generated `$CONTRIBUTORS` variable. Refer to [Exclude Contributors](#exclude-contributors) to learn more about this option.                                                                                          |
+| `new-contributor-template` | Optional | The template to use for each new contributor in `$NEW_CONTRIBUTORS`. Use [new contributor template variables](#new-contributor-template-variables) to insert values. Default: `"* $AUTHOR_MENTION made their first contribution in #$NUMBER"`.                   |
 | `no-contributors-template` | Optional | The template to use for `$CONTRIBUTORS` when there's no contributors to list. Default: `"No contributors"`.                                                                                                                                              |
 | `replacers`                | Optional | Search and replace content in the generated changelog body. Refer to [Replacers](#replacers) to learn more about this option.                                                                                                                            |
 | `sort-by`                  | Optional | Sort changelog by merged_at or title. Can be one of: `merged_at`, `title`. Default: `merged_at`.                                                                                                                                                         |
@@ -152,7 +153,7 @@ You can use any of the following variables in your `template`, `header` and
 | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `$CHANGES`          | The markdown list of pull requests that have been merged.                                                             |
 | `$CONTRIBUTORS`     | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
-| `$NEW_CONTRIBUTORS` | A Markdown section listing pull request authors making their first contribution and the corresponding pull request.  |
+| `$NEW_CONTRIBUTORS` | A Markdown list of pull request authors making their first contribution and the corresponding pull request.                       |
 | `$PREVIOUS_TAG`     | The previous releases’s tag.                                                                                          |
 | `$REPOSITORY`       | Current Repository                                                                                                    |
 | `$OWNER`            | Current Repository Owner                                                                                              |
@@ -269,6 +270,18 @@ The example above:
 - uses the category with no `when` as the fallback when nothing else matches
 - picks the highest semver increment across matching categories
 
+## New Contributor Template Variables
+
+You can use any of the following variables in `new-contributor-template`:
+
+| Variable          | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `$AUTHOR`         | The new contributor’s username, e.g. `gracehopper`.                         |
+| `$AUTHOR_MENTION` | The new contributor’s GitHub mention, e.g. `@gracehopper`.                  |
+| `$AUTHOR_URL`     | The URL of the new contributor’s GitHub profile, e.g. `https://github.com/gracehopper`. |
+| `$NUMBER`         | The number of the contributor’s first pull request, e.g. `42`.              |
+| `$URL`            | The URL of the contributor’s first pull request, e.g. `https://github.com/octocat/repo/pull/42`. |
+
 ## Change Template Variables
 
 You can use any of the following variables in `change-template`:
@@ -279,6 +292,7 @@ You can use any of the following variables in `change-template`:
 | `$CATEGORY`      | The title of the category that matched the pull request, preserving its configured case. Empty for uncategorized pull requests.                                                                                                                                                                                                                                                       |
 | `$TITLE`         | The title of the pull request, e.g. `Add alien technology`. Any characters excluding @ and # matching `change-title-escapes` will be prepended with a backslash so that they will appear verbatim instead of being interpreted as markdown format characters. @s and #s if present in `change-title-escapes` will be appended with an HTML comment so that they don't become mentions. |
 | `$AUTHOR`        | The pull request author’s username, e.g. `gracehopper`.                                                                                                                                                                                                                                                                                                                                |
+| `$AUTHOR_URL`    | The pull request author’s GitHub profile URL, e.g. `https://github.com/gracehopper`.                                                                                                                                                                                                                                                                                                   |
 | `$AUTHORS`       | The pull request author and its associated commit authors rendered with `change-author-template` and joined with `change-authors-separator`, with the pull request author first.                                                                                                                                                                                                       |
 | `$BODY`          | The body of the pull request e.g. `Fixed spelling mistake`.                                                                                                                                                                                                                                                                                                                            |
 | `$URL`           | The URL of the pull request e.g. `https://github.com/octocat/repo/pull/42`.                                                                                                                                                                                                                                                                                                            |

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -369,6 +369,10 @@ var exclusiveConfigSchema = object({
 	*/
 	"exclude-contributors": array(string()).optional().default([]),
 	/**
+	* The template to use for each new contributor in `$NEW_CONTRIBUTORS`.
+	*/
+	"new-contributor-template": string().optional().default("* $AUTHOR_MENTION made their first contribution in #$NUMBER"),
+	/**
 	* The template to use for `$CONTRIBUTORS` when there's no contributors to list.
 	*/
 	"no-contributors-template": string().optional().default("No contributors"),
@@ -2003,7 +2007,7 @@ var generateAuthorsSentence = (params) => {
 	if (mentions.length > 1) return `${mentions.slice(0, -1).join(", ")} and ${mentions.slice(-1)}`;
 	return mentions[0];
 };
-var generateNewContributorsSection = (params) => {
+var generateNewContributorsList = (params) => {
 	const { pullRequests, newContributorLogins, config } = params;
 	const firstPullRequestByLogin = /* @__PURE__ */ new Map();
 	const includedPullRequestKeys = new Set(filterPullRequestsByPreCategories(pullRequests, config.categories).map(pullRequestKey));
@@ -2014,7 +2018,16 @@ var generateNewContributorsSection = (params) => {
 	}
 	const entries = [...firstPullRequestByLogin.entries()].filter(([, pullRequest]) => includedPullRequestKeys.has(pullRequestKey(pullRequest))).sort(([, a], [, b]) => (a.mergedAt ?? "").localeCompare(b.mergedAt ?? "") || a.number - b.number);
 	if (entries.length === 0) return "";
-	return `## New Contributors\n\n${entries.map(([login, pullRequest]) => `* @${login} made their first contribution in #${pullRequest.number}`).join("\n")}`;
+	return entries.map(([login, pullRequest]) => renderTemplate({
+		template: config["new-contributor-template"],
+		object: {
+			$AUTHOR: login,
+			$AUTHOR_MENTION: `@${login}`,
+			$AUTHOR_URL: pullRequest.author?.url,
+			$NUMBER: pullRequest.number,
+			$URL: pullRequest.url
+		}
+	})).join("\n");
 };
 //#endregion
 //#region src/actions/drafter/lib/build-release-payload/pull-request-to-string.ts
@@ -2046,6 +2059,7 @@ var pullRequestToString = (params) => params.pullRequests.map((pullRequest) => {
 				authorsFinalSeparator: params.config["change-authors-final-separator"]
 			}),
 			$AUTHOR: pullAuthor,
+			$AUTHOR_URL: pullRequest.author?.url ?? "",
 			$BODY: pullRequest.body,
 			$URL: pullRequest.url,
 			$BASE_REF_NAME: pullRequest.baseRefName,
@@ -2485,7 +2499,7 @@ var buildReleasePayload = (params) => {
 				pullRequests: sortedPullRequests,
 				config
 			}),
-			$NEW_CONTRIBUTORS: generateNewContributorsSection({
+			$NEW_CONTRIBUTORS: generateNewContributorsList({
 				pullRequests: sortedPullRequests,
 				newContributorLogins,
 				config

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2006,12 +2006,13 @@ var generateAuthorsSentence = (params) => {
 var generateNewContributorsSection = (params) => {
 	const { pullRequests, newContributorLogins, config } = params;
 	const firstPullRequestByLogin = /* @__PURE__ */ new Map();
-	for (const pullRequest of filterPullRequestsByPreCategories(pullRequests, config.categories)) {
+	const includedPullRequestKeys = new Set(filterPullRequestsByPreCategories(pullRequests, config.categories).map(pullRequestKey));
+	for (const pullRequest of pullRequests) {
 		if (!pullRequest.author || !newContributorLogins.has(pullRequest.author.login) || config["exclude-contributors"].includes(pullRequest.author.login)) continue;
 		const previous = firstPullRequestByLogin.get(pullRequest.author.login);
 		if (!previous || (pullRequest.mergedAt ?? "") < (previous.mergedAt ?? "")) firstPullRequestByLogin.set(pullRequest.author.login, pullRequest);
 	}
-	const entries = [...firstPullRequestByLogin.entries()].sort(([, a], [, b]) => (a.mergedAt ?? "").localeCompare(b.mergedAt ?? "") || a.number - b.number);
+	const entries = [...firstPullRequestByLogin.entries()].filter(([, pullRequest]) => includedPullRequestKeys.has(pullRequestKey(pullRequest))).sort(([, a], [, b]) => (a.mergedAt ?? "").localeCompare(b.mergedAt ?? "") || a.number - b.number);
 	if (entries.length === 0) return "";
 	return `## New Contributors\n\n${entries.map(([login, pullRequest]) => `* @${login} made their first contribution in #${pullRequest.number}`).join("\n")}`;
 };

--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -2003,6 +2003,18 @@ var generateAuthorsSentence = (params) => {
 	if (mentions.length > 1) return `${mentions.slice(0, -1).join(", ")} and ${mentions.slice(-1)}`;
 	return mentions[0];
 };
+var generateNewContributorsSection = (params) => {
+	const { pullRequests, newContributorLogins, config } = params;
+	const firstPullRequestByLogin = /* @__PURE__ */ new Map();
+	for (const pullRequest of filterPullRequestsByPreCategories(pullRequests, config.categories)) {
+		if (!pullRequest.author || !newContributorLogins.has(pullRequest.author.login) || config["exclude-contributors"].includes(pullRequest.author.login)) continue;
+		const previous = firstPullRequestByLogin.get(pullRequest.author.login);
+		if (!previous || (pullRequest.mergedAt ?? "") < (previous.mergedAt ?? "")) firstPullRequestByLogin.set(pullRequest.author.login, pullRequest);
+	}
+	const entries = [...firstPullRequestByLogin.entries()].sort(([, a], [, b]) => (a.mergedAt ?? "").localeCompare(b.mergedAt ?? "") || a.number - b.number);
+	if (entries.length === 0) return "";
+	return `## New Contributors\n\n${entries.map(([login, pullRequest]) => `* @${login} made their first contribution in #${pullRequest.number}`).join("\n")}`;
+};
 //#endregion
 //#region src/actions/drafter/lib/build-release-payload/pull-request-to-string.ts
 var pullRequestToString = (params) => params.pullRequests.map((pullRequest) => {
@@ -2445,7 +2457,7 @@ var last_not_found_default = "> [!WARNING]\n> Release Drafter could not find a p
 * Previously known as `generateReleaseInfo`.
 */
 var buildReleasePayload = (params) => {
-	const { commits, config, input, lastRelease, pullRequests } = params;
+	const { commits, config, input, lastRelease, newContributorLogins = /* @__PURE__ */ new Set(), pullRequests } = params;
 	info(`Building release payload and body...`);
 	const sortedPullRequests = sortPullRequests({
 		pullRequests,
@@ -2470,6 +2482,11 @@ var buildReleasePayload = (params) => {
 			$CONTRIBUTORS: generateContributorsSentence({
 				commits,
 				pullRequests: sortedPullRequests,
+				config
+			}),
+			$NEW_CONTRIBUTORS: generateNewContributorsSection({
+				pullRequests: sortedPullRequests,
+				newContributorLogins,
 				config
 			}),
 			$OWNER: context.repo.owner,
@@ -4227,6 +4244,21 @@ var findRecentMergedPullRequests = async (params) => {
 };
 //#endregion
 //#region src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
+var findNewContributorLogins = async (pullRequests) => {
+	const firstMergedAtByLogin = /* @__PURE__ */ new Map();
+	for (const pullRequest of pullRequests) {
+		if (pullRequest.author?.__typename !== "User" || !pullRequest.mergedAt) continue;
+		const previous = firstMergedAtByLogin.get(pullRequest.author.login);
+		if (!previous || pullRequest.mergedAt < previous) firstMergedAtByLogin.set(pullRequest.author.login, pullRequest.mergedAt);
+	}
+	const candidates = [...firstMergedAtByLogin];
+	if (candidates.length === 0) return /* @__PURE__ */ new Set();
+	const variables = Object.fromEntries(candidates.map(([login, mergedAt], index) => [`query${index}`, `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${login} merged:<${mergedAt}`]));
+	const data = await getOctokit().graphql(`query findPreviousContributions(${candidates.map((_, index) => `$query${index}: String!`).join(", ")}) {
+      ${candidates.map((_, index) => `author${index}: search(query: $query${index}, type: ISSUE, first: 1) { issueCount }`).join("\n")}
+    }`, variables);
+	return new Set(candidates.flatMap(([login], index) => data[`author${index}`]?.issueCount === 0 ? [login] : []));
+};
 var findPullRequests = async (params) => {
 	const sharedComparisonParams = {
 		name: context.repo.repo,
@@ -4243,6 +4275,7 @@ var findPullRequests = async (params) => {
 		warning("A previous (published) release is required to find changes");
 		return {
 			commits: [],
+			newContributorLogins: /* @__PURE__ */ new Set(),
 			pullRequests: []
 		};
 	}
@@ -4276,9 +4309,15 @@ var findPullRequests = async (params) => {
 		repo: context.repo.repo,
 		pullRequests
 	}) : /* @__PURE__ */ new Map();
+	const newContributorLogins = [
+		params.config.header,
+		params.config.template,
+		params.config.footer
+	].some((template) => template?.includes("$NEW_CONTRIBUTORS")) ? await findNewContributorLogins(pullRequests) : /* @__PURE__ */ new Set();
 	info(`Found ${pullRequests.length} merged pull requests targeting ${context.repo.owner}/${context.repo.repo}${pullRequests.length > 0 ? `: ${pullRequests.map((pr) => `#${pr.number}`).join(", ")}` : "."}`);
 	return {
 		commits,
+		newContributorLogins,
 		pullRequests: pullRequests.map((pullRequest) => shouldLoadPullRequestChangedFiles ? {
 			...pullRequest,
 			changedFiles: pullRequestChangedFiles.get(`${pullRequest.baseRepository?.nameWithOwner}#${pullRequest.number}`)
@@ -4363,7 +4402,7 @@ var main = async (params) => {
 	*/
 	const { config, input } = params;
 	const { draftRelease, lastRelease } = await findPreviousReleases(config);
-	const { commits, pullRequests } = await findPullRequests({
+	const { commits, newContributorLogins, pullRequests } = await findPullRequests({
 		lastRelease,
 		config
 	});
@@ -4372,6 +4411,7 @@ var main = async (params) => {
 		config,
 		input,
 		lastRelease,
+		newContributorLogins,
 		pullRequests
 	});
 	return {

--- a/drafter/schema.json
+++ b/drafter/schema.json
@@ -110,6 +110,10 @@
         "type": "string"
       }
     },
+    "new-contributor-template": {
+      "default": "* $AUTHOR_MENTION made their first contribution in #$NUMBER",
+      "type": "string"
+    },
     "no-contributors-template": {
       "default": "No contributors",
       "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -110,6 +110,10 @@
         "type": "string"
       }
     },
+    "new-contributor-template": {
+      "default": "* $AUTHOR_MENTION made their first contribution in #$NUMBER",
+      "type": "string"
+    },
     "no-contributors-template": {
       "default": "No contributors",
       "type": "string"

--- a/src/actions/drafter/config/schemas/config.schema.ts
+++ b/src/actions/drafter/config/schemas/config.schema.ts
@@ -292,6 +292,12 @@ export const exclusiveConfigSchema = object({
    */
   'exclude-contributors': array(string()).optional().default([]),
   /**
+   * The template to use for each new contributor in `$NEW_CONTRIBUTORS`.
+   */
+  'new-contributor-template': string()
+    .optional()
+    .default('* $AUTHOR_MENTION made their first contribution in #$NUMBER'),
+  /**
    * The template to use for `$CONTRIBUTORS` when there's no contributors to list.
    */
   'no-contributors-template': string().optional().default('No contributors'),

--- a/src/actions/drafter/lib/build-release-payload/build-release-payload.ts
+++ b/src/actions/drafter/lib/build-release-payload/build-release-payload.ts
@@ -5,7 +5,10 @@ import type { ExclusiveInput, ParsedConfig } from '../../config/index.ts'
 import type { findPreviousReleases } from '../find-previous-releases/index.ts'
 import type { findPullRequests } from '../find-pull-requests/index.ts'
 import { generateChangeLog } from './generate-changelog.ts'
-import { generateContributorsSentence } from './generate-contributors-sentence.ts'
+import {
+  generateContributorsSentence,
+  generateNewContributorsSection,
+} from './generate-contributors-sentence.ts'
 import { getVersionInfo } from './get-version-info.ts'
 import { renderReleaseName } from './render-release-name.ts'
 import { renderTagName } from './render-tag-name.ts'
@@ -50,9 +53,17 @@ export const buildReleasePayload = (params: {
   >
   input: ExclusiveInput
   lastRelease: Awaited<ReturnType<typeof findPreviousReleases>>['lastRelease']
+  newContributorLogins?: ReadonlySet<string>
   pullRequests: Awaited<ReturnType<typeof findPullRequests>>['pullRequests']
 }) => {
-  const { commits, config, input, lastRelease, pullRequests } = params
+  const {
+    commits,
+    config,
+    input,
+    lastRelease,
+    newContributorLogins = new Set<string>(),
+    pullRequests,
+  } = params
 
   core.info(`Building release payload and body...`)
 
@@ -81,6 +92,11 @@ export const buildReleasePayload = (params: {
       $CONTRIBUTORS: generateContributorsSentence({
         commits,
         pullRequests: sortedPullRequests,
+        config,
+      }),
+      $NEW_CONTRIBUTORS: generateNewContributorsSection({
+        pullRequests: sortedPullRequests,
+        newContributorLogins,
         config,
       }),
       $OWNER: context.repo.owner,

--- a/src/actions/drafter/lib/build-release-payload/build-release-payload.ts
+++ b/src/actions/drafter/lib/build-release-payload/build-release-payload.ts
@@ -7,7 +7,7 @@ import type { findPullRequests } from '../find-pull-requests/index.ts'
 import { generateChangeLog } from './generate-changelog.ts'
 import {
   generateContributorsSentence,
-  generateNewContributorsSection,
+  generateNewContributorsList,
 } from './generate-contributors-sentence.ts'
 import { getVersionInfo } from './get-version-info.ts'
 import { renderReleaseName } from './render-release-name.ts'
@@ -41,6 +41,7 @@ export const buildReleasePayload = (params: {
     | 'change-authors-final-separator'
     | 'category-template'
     | 'exclude-contributors'
+    | 'new-contributor-template'
     | 'no-contributors-template'
     | 'prerelease'
     | 'version-template'
@@ -94,7 +95,7 @@ export const buildReleasePayload = (params: {
         pullRequests: sortedPullRequests,
         config,
       }),
-      $NEW_CONTRIBUTORS: generateNewContributorsSection({
+      $NEW_CONTRIBUTORS: generateNewContributorsList({
         pullRequests: sortedPullRequests,
         newContributorLogins,
         config,

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -167,10 +167,13 @@ export const generateAuthorsSentence = (params: {
   return mentions[0]
 }
 
-export const generateNewContributorsSection = (params: {
+export const generateNewContributorsList = (params: {
   pullRequests: Awaited<ReturnType<typeof findPullRequests>>['pullRequests']
   newContributorLogins: ReadonlySet<string>
-  config: Pick<ParsedConfig, 'categories' | 'exclude-contributors'>
+  config: Pick<
+    ParsedConfig,
+    'categories' | 'exclude-contributors' | 'new-contributor-template'
+  >
 }) => {
   const { pullRequests, newContributorLogins, config } = params
   const firstPullRequestByLogin = new Map<string, PullRequest>()
@@ -206,10 +209,18 @@ export const generateNewContributorsSection = (params: {
     )
   if (entries.length === 0) return ''
 
-  return `## New Contributors\n\n${entries
-    .map(
-      ([login, pullRequest]) =>
-        `* @${login} made their first contribution in #${pullRequest.number}`,
+  return entries
+    .map(([login, pullRequest]) =>
+      renderTemplate({
+        template: config['new-contributor-template'],
+        object: {
+          $AUTHOR: login,
+          $AUTHOR_MENTION: `@${login}`,
+          $AUTHOR_URL: pullRequest.author?.url,
+          $NUMBER: pullRequest.number,
+          $URL: pullRequest.url,
+        },
+      }),
     )
-    .join('\n')}`
+    .join('\n')
 }

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -166,3 +166,43 @@ export const generateAuthorsSentence = (params: {
   }
   return mentions[0]
 }
+
+export const generateNewContributorsSection = (params: {
+  pullRequests: Awaited<ReturnType<typeof findPullRequests>>['pullRequests']
+  newContributorLogins: ReadonlySet<string>
+  config: Pick<ParsedConfig, 'categories' | 'exclude-contributors'>
+}) => {
+  const { pullRequests, newContributorLogins, config } = params
+  const firstPullRequestByLogin = new Map<string, PullRequest>()
+
+  for (const pullRequest of filterPullRequestsByPreCategories(
+    pullRequests,
+    config.categories,
+  )) {
+    if (
+      !pullRequest.author ||
+      !newContributorLogins.has(pullRequest.author.login) ||
+      config['exclude-contributors'].includes(pullRequest.author.login)
+    ) {
+      continue
+    }
+
+    const previous = firstPullRequestByLogin.get(pullRequest.author.login)
+    if (!previous || (pullRequest.mergedAt ?? '') < (previous.mergedAt ?? '')) {
+      firstPullRequestByLogin.set(pullRequest.author.login, pullRequest)
+    }
+  }
+
+  const entries = [...firstPullRequestByLogin.entries()].sort(
+    ([, a], [, b]) =>
+      (a.mergedAt ?? '').localeCompare(b.mergedAt ?? '') || a.number - b.number,
+  )
+  if (entries.length === 0) return ''
+
+  return `## New Contributors\n\n${entries
+    .map(
+      ([login, pullRequest]) =>
+        `* @${login} made their first contribution in #${pullRequest.number}`,
+    )
+    .join('\n')}`
+}

--- a/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
+++ b/src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts
@@ -174,11 +174,13 @@ export const generateNewContributorsSection = (params: {
 }) => {
   const { pullRequests, newContributorLogins, config } = params
   const firstPullRequestByLogin = new Map<string, PullRequest>()
+  const includedPullRequestKeys = new Set(
+    filterPullRequestsByPreCategories(pullRequests, config.categories).map(
+      pullRequestKey,
+    ),
+  )
 
-  for (const pullRequest of filterPullRequestsByPreCategories(
-    pullRequests,
-    config.categories,
-  )) {
+  for (const pullRequest of pullRequests) {
     if (
       !pullRequest.author ||
       !newContributorLogins.has(pullRequest.author.login) ||
@@ -193,10 +195,15 @@ export const generateNewContributorsSection = (params: {
     }
   }
 
-  const entries = [...firstPullRequestByLogin.entries()].sort(
-    ([, a], [, b]) =>
-      (a.mergedAt ?? '').localeCompare(b.mergedAt ?? '') || a.number - b.number,
-  )
+  const entries = [...firstPullRequestByLogin.entries()]
+    .filter(([, pullRequest]) =>
+      includedPullRequestKeys.has(pullRequestKey(pullRequest)),
+    )
+    .sort(
+      ([, a], [, b]) =>
+        (a.mergedAt ?? '').localeCompare(b.mergedAt ?? '') ||
+        a.number - b.number,
+    )
   if (entries.length === 0) return ''
 
   return `## New Contributors\n\n${entries

--- a/src/actions/drafter/lib/build-release-payload/pull-request-to-string.ts
+++ b/src/actions/drafter/lib/build-release-payload/pull-request-to-string.ts
@@ -56,6 +56,7 @@ export const pullRequestToString = (params: {
               params.config['change-authors-final-separator'],
           }),
           $AUTHOR: pullAuthor,
+          $AUTHOR_URL: pullRequest.author?.url ?? '',
           $BODY: pullRequest.body,
           $URL: pullRequest.url,
           $BASE_REF_NAME: pullRequest.baseRefName,

--- a/src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
+++ b/src/actions/drafter/lib/find-pull-requests/find-pull-requests.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import { context } from '@actions/github'
-import { getPullRequestsChangedFiles } from '#src/common/index.ts'
+import { getOctokit, getPullRequestsChangedFiles } from '#src/common/index.ts'
 import { needsPullRequestChangedFiles } from '../../common/category-matching.ts'
 import type { ParsedConfig } from '../../config/index.ts'
 import type { findPreviousReleases } from '../find-previous-releases/index.ts'
@@ -9,6 +9,49 @@ import {
   findRecentMergedPullRequests,
   type RecentMergedPullRequest,
 } from './find-recent-merged-pull-requests.ts'
+
+const findNewContributorLogins = async (
+  pullRequests: Array<{
+    author?: { __typename?: string; login: string } | null
+    mergedAt?: string | null
+  }>,
+) => {
+  const firstMergedAtByLogin = new Map<string, string>()
+
+  for (const pullRequest of pullRequests) {
+    if (pullRequest.author?.__typename !== 'User' || !pullRequest.mergedAt)
+      continue
+
+    const previous = firstMergedAtByLogin.get(pullRequest.author.login)
+    if (!previous || pullRequest.mergedAt < previous) {
+      firstMergedAtByLogin.set(pullRequest.author.login, pullRequest.mergedAt)
+    }
+  }
+
+  const candidates = [...firstMergedAtByLogin]
+  if (candidates.length === 0) return new Set<string>()
+
+  const variables = Object.fromEntries(
+    candidates.map(([login, mergedAt], index) => [
+      `query${index}`,
+      `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${login} merged:<${mergedAt}`,
+    ]),
+  )
+  const data = await getOctokit().graphql<
+    Record<string, { issueCount: number }>
+  >(
+    `query findPreviousContributions(${candidates.map((_, index) => `$query${index}: String!`).join(', ')}) {
+      ${candidates.map((_, index) => `author${index}: search(query: $query${index}, type: ISSUE, first: 1) { issueCount }`).join('\n')}
+    }`,
+    variables,
+  )
+
+  return new Set(
+    candidates.flatMap(([login], index) =>
+      data[`author${index}`]?.issueCount === 0 ? [login] : [],
+    ),
+  )
+}
 
 export const findPullRequests = async (params: {
   lastRelease: Awaited<ReturnType<typeof findPreviousReleases>>['lastRelease']
@@ -30,7 +73,11 @@ export const findPullRequests = async (params: {
 
   if (!params.lastRelease?.tag_name) {
     core.warning('A previous (published) release is required to find changes')
-    return { commits: [], pullRequests: [] }
+    return {
+      commits: [],
+      newContributorLogins: new Set<string>(),
+      pullRequests: [],
+    }
   }
 
   core.info(
@@ -107,6 +154,14 @@ export const findPullRequests = async (params: {
         pullRequests,
       })
     : new Map<string, string[]>()
+  const usesNewContributors = [
+    params.config.header,
+    params.config.template,
+    params.config.footer,
+  ].some((template) => template?.includes('$NEW_CONTRIBUTORS'))
+  const newContributorLogins = usesNewContributors
+    ? await findNewContributorLogins(pullRequests)
+    : new Set<string>()
 
   core.info(
     `Found ${pullRequests.length} merged pull requests targeting ${context.repo.owner}/${context.repo.repo}${
@@ -118,6 +173,7 @@ export const findPullRequests = async (params: {
 
   return {
     commits,
+    newContributorLogins,
     pullRequests: pullRequests.map((pullRequest) =>
       shouldLoadPullRequestChangedFiles
         ? {

--- a/src/actions/drafter/main.ts
+++ b/src/actions/drafter/main.ts
@@ -22,16 +22,18 @@ export const main = async (params: {
 
   const { draftRelease, lastRelease } = await findPreviousReleases(config)
 
-  const { commits, pullRequests } = await findPullRequests({
-    lastRelease,
-    config,
-  })
+  const { commits, newContributorLogins, pullRequests } =
+    await findPullRequests({
+      lastRelease,
+      config,
+    })
 
   const releasePayload = buildReleasePayload({
     commits,
     config,
     input,
     lastRelease,
+    newContributorLogins,
     pullRequests,
   })
 

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -997,6 +997,47 @@ describe('generate contributors sentence', () => {
     )
   })
 
+  it('omits a contributor whose actual first pull request is excluded', () => {
+    const author = {
+      __typename: 'User' as const,
+      login: 'first-timer',
+      url: 'https://github.com/first-timer',
+    }
+    const firstPullRequest = {
+      ...userPullRequest,
+      number: 41,
+      mergedAt: '2024-01-01T00:00:00Z',
+      author,
+      labels: {
+        __typename: 'LabelConnection' as const,
+        nodes: [{ __typename: 'Label' as const, name: 'skip-changelog' }],
+      },
+    }
+    const laterPullRequest = {
+      ...userPullRequest,
+      number: 42,
+      mergedAt: '2024-01-02T00:00:00Z',
+      author,
+    }
+    const skipConfig = mergeInputAndConfig({
+      config: configSchema.parse({
+        template: '$NEW_CONTRIBUTORS',
+        categories: [
+          { type: 'pre-exclude', when: { label: 'skip-changelog' } },
+        ],
+      }),
+      input: actionInputSchema.parse({ token: 'test' }),
+    })
+
+    expect(
+      generateNewContributorsSection({
+        pullRequests: [laterPullRequest, firstPullRequest],
+        newContributorLogins: new Set(['first-timer']),
+        config: skipConfig,
+      }),
+    ).toBe('')
+  })
+
   it('excludes contributors whose pull requests are excluded', () => {
     const skippedPullRequest = {
       ...botPullRequest,

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -7,7 +7,10 @@ import {
   mergeInputAndConfig,
 } from '#src/actions/drafter/config/index.ts'
 import { generateChangeLog } from '#src/actions/drafter/lib/build-release-payload/generate-changelog.ts'
-import { generateContributorsSentence } from '#src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts'
+import {
+  generateContributorsSentence,
+  generateNewContributorsSection,
+} from '#src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts'
 import { buildReleasePayload } from '#src/actions/drafter/lib/index.ts'
 import { mockContext, mocks as sharedMocks } from '#tests/mocks/index.ts'
 
@@ -970,6 +973,28 @@ describe('generate contributors sentence', () => {
         config,
       }),
     ).toBe('@ghost')
+  })
+
+  it('renders the GitHub-style new contributors section', () => {
+    const newContributorPullRequest = {
+      ...userPullRequest,
+      number: 42,
+      author: {
+        __typename: 'User' as const,
+        login: 'first-timer',
+        url: 'https://github.com/first-timer',
+      },
+    }
+
+    expect(
+      generateNewContributorsSection({
+        pullRequests: [userPullRequest, newContributorPullRequest],
+        newContributorLogins: new Set(['first-timer']),
+        config,
+      }),
+    ).toBe(
+      '## New Contributors\n\n* @first-timer made their first contribution in #42',
+    )
   })
 
   it('excludes contributors whose pull requests are excluded', () => {

--- a/src/tests/drafter/build-release-payload.test.ts
+++ b/src/tests/drafter/build-release-payload.test.ts
@@ -9,7 +9,7 @@ import {
 import { generateChangeLog } from '#src/actions/drafter/lib/build-release-payload/generate-changelog.ts'
 import {
   generateContributorsSentence,
-  generateNewContributorsSection,
+  generateNewContributorsList,
 } from '#src/actions/drafter/lib/build-release-payload/generate-contributors-sentence.ts'
 import { buildReleasePayload } from '#src/actions/drafter/lib/index.ts'
 import { mockContext, mocks as sharedMocks } from '#tests/mocks/index.ts'
@@ -826,6 +826,21 @@ describe('generate contributors sentence', () => {
     )
   })
 
+  it('renders pull request authors as markdown links', () => {
+    expect(
+      generateChangeLog({
+        pullRequests: [pullRequest],
+        config: {
+          ...config,
+          'change-template':
+            '* $TITLE ([#$NUMBER]($URL)) [$AUTHOR]($AUTHOR_URL)',
+        },
+      }),
+    ).toMatchInlineSnapshot(
+      `"* Adds missing <example> ([#3](https://github.com)) [octocat](https://github.com/octocat)"`,
+    )
+  })
+
   it('renders deleted pull request authors with the author template', () => {
     expect(
       generateChangeLog({
@@ -975,7 +990,7 @@ describe('generate contributors sentence', () => {
     ).toBe('@ghost')
   })
 
-  it('renders the GitHub-style new contributors section', () => {
+  it('renders the GitHub-style new contributors list', () => {
     const newContributorPullRequest = {
       ...userPullRequest,
       number: 42,
@@ -987,13 +1002,38 @@ describe('generate contributors sentence', () => {
     }
 
     expect(
-      generateNewContributorsSection({
+      generateNewContributorsList({
         pullRequests: [userPullRequest, newContributorPullRequest],
         newContributorLogins: new Set(['first-timer']),
         config,
       }),
-    ).toBe(
-      '## New Contributors\n\n* @first-timer made their first contribution in #42',
+    ).toBe('* @first-timer made their first contribution in #42')
+  })
+
+  it('renders new contributors with a custom template', () => {
+    const newContributorPullRequest = {
+      ...userPullRequest,
+      number: 42,
+      url: 'https://github.com/release-drafter/release-drafter/pull/42',
+      author: {
+        __typename: 'User' as const,
+        login: 'first-timer',
+        url: 'https://github.com/first-timer',
+      },
+    }
+
+    expect(
+      generateNewContributorsList({
+        pullRequests: [newContributorPullRequest],
+        newContributorLogins: new Set(['first-timer']),
+        config: {
+          ...config,
+          'new-contributor-template':
+            '* [$AUTHOR]($AUTHOR_URL) made their first contribution in [#$NUMBER]($URL)',
+        },
+      }),
+    ).toMatchInlineSnapshot(
+      `"* [first-timer](https://github.com/first-timer) made their first contribution in [#42](https://github.com/release-drafter/release-drafter/pull/42)"`,
     )
   })
 
@@ -1030,7 +1070,7 @@ describe('generate contributors sentence', () => {
     })
 
     expect(
-      generateNewContributorsSection({
+      generateNewContributorsList({
         pullRequests: [laterPullRequest, firstPullRequest],
         newContributorLogins: new Set(['first-timer']),
         config: skipConfig,

--- a/src/tests/drafter/find-pull-requests.test.ts
+++ b/src/tests/drafter/find-pull-requests.test.ts
@@ -10,6 +10,7 @@ import { mockContext } from '../mocks/index.ts'
 
 const localMocks = vi.hoisted(() => ({
   findCommitsInComparison: vi.fn(),
+  graphql: vi.fn(),
   paginate: vi.fn(),
   listFiles: vi.fn(),
 }))
@@ -26,6 +27,7 @@ vi.mock(
 vi.mock('#src/common/get-octokit.ts', () => ({
   getOctokit: () =>
     ({
+      graphql: localMocks.graphql as unknown as Octokit['graphql'],
       paginate: localMocks.paginate as unknown as Octokit['paginate'],
       rest: {
         pulls: {
@@ -88,8 +90,52 @@ describe('findPullRequests', () => {
   beforeEach(async () => {
     await mockContext('push')
     localMocks.findCommitsInComparison.mockReset()
+    localMocks.graphql.mockReset()
     localMocks.paginate.mockReset()
     localMocks.listFiles.mockReset()
+  })
+
+  it('identifies a first-time contribution from merge history', async () => {
+    const commit = makeCommit('first-contribution', 42)
+    const pullRequest = commit.associatedPullRequests.nodes[0]
+    pullRequest.author.login = 'first-timer'
+    pullRequest.mergedAt = '2026-07-11T15:17:17Z'
+    localMocks.findCommitsInComparison.mockResolvedValue([
+      commit,
+      makeCommit('earlier-contributor', 1),
+    ])
+    localMocks.graphql.mockResolvedValue({
+      author0: { issueCount: 0 },
+      author1: { issueCount: 1 },
+    })
+
+    const config = mergeInputAndConfig({
+      config: configSchema.parse({
+        template: '$NEW_CONTRIBUTORS',
+        commitish: 'refs/heads/main',
+      }),
+      input: commonConfigSchema.parse({}),
+    })
+
+    const result = await findPullRequests({
+      lastRelease: { tag_name: 'v1.0.0' } as Awaited<
+        ReturnType<
+          typeof import('#src/actions/drafter/lib/find-previous-releases/index.ts').findPreviousReleases
+        >
+      >['lastRelease'],
+      config,
+    })
+
+    expect(result.newContributorLogins).toEqual(new Set(['first-timer']))
+    expect(localMocks.graphql).toHaveBeenCalledWith(
+      expect.stringContaining('query findPreviousContributions'),
+      {
+        query0:
+          'repo:toolmantim/release-drafter-test-project is:pr is:merged author:first-timer merged:<2026-07-11T15:17:17Z',
+        query1:
+          'repo:toolmantim/release-drafter-test-project is:pr is:merged author:octocat merged:<2026-01-01T00:00:00Z',
+      },
+    )
   })
 
   it('loads changed files for path-based pre-include categories', async () => {


### PR DESCRIPTION
## Summary

- add a `$NEW_CONTRIBUTORS` template variable matching the GitHub-generated release notes format
- identify first-time contributors by checking for earlier merged pull requests in one batched GraphQL request
- render the contributor and first pull request, for example: `@first-timer made their first contribution in #42`
- document the variable and regenerate `dist/`

## Dependencies

No dependency changes.

## Testing

- `npm run all`
- 419 tests passed

## Reviewer context

The history lookup only runs when `$NEW_CONTRIBUTORS` is present in the template, header, or footer. `authorAssociation` is intentionally not used because it changes to `CONTRIBUTOR` after a first pull request is merged.

Closes #1001

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add new contributors section to release drafter with `$NEW_CONTRIBUTORS` template variable
> - Adds a `new-contributor-template` config key (default: `* $AUTHOR_MENTION made their first contribution in #$NUMBER`) and a `$NEW_CONTRIBUTORS` placeholder for use in release body templates.
> - When `$NEW_CONTRIBUTORS` is detected in any template, [`find-pull-requests.ts`](https://github.com/release-drafter/release-drafter/pull/1645/files#diff-d55a9e414d05cb59c5dd61b3a18253f95b7cfc90461c36096c8f5a7ee242bc51) queries GitHub's GraphQL search API to identify first-time contributors by checking for prior merged PRs.
> - [`generate-contributors-sentence.ts`](https://github.com/release-drafter/release-drafter/pull/1645/files#diff-bb9ffcc9a62f8d35d98da8fca788d46992a1d58794f4962cb2044b144344d10c) renders the contributor list, filtering out excluded categories and sorting by merge date.
> - Also adds `$AUTHOR_URL` as a new variable available in change templates via [`pull-request-to-string.ts`](https://github.com/release-drafter/release-drafter/pull/1645/files#diff-eb1d3a117801d32cbd4606100666d62f3e3cd9b0d3cd9531b417323f8488d777).
> - Risk: when `$NEW_CONTRIBUTORS` is used, one GraphQL search query per contributor candidate is issued at release draft time, which may increase API usage noticeably for repos with many contributors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16b4d3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->