### PR TITLE
fix: .github in legacy `_extends` refs

### DIFF
--- a/dist/chunks/ignore.js
+++ b/dist/chunks/ignore.js
@@ -31119,7 +31119,8 @@ function parseConfigTarget(target, context) {
 	}
 	if (!hasRepoSpecifier && scheme !== "file") {
 		const targetWithoutRef = hasRefSpecifier ? _target.slice(0, _target.indexOf("@")) : _target;
-		if (!targetWithoutRef.includes(".")) {
+		const repoName = targetWithoutRef.split("/").at(-1) || "";
+		if (!repoName.includes(".") || repoName === ".github") {
 			if (hasRefSpecifier) _target = `${targetWithoutRef}:${_target.slice(_target.indexOf("@"))}`;
 			else _target = `${_target}:`;
 			hasRepoSpecifier = true;

--- a/src/common/config/parse-config-target.ts
+++ b/src/common/config/parse-config-target.ts
@@ -47,14 +47,15 @@ export function parseConfigTarget(
       throw getErr('Local file targets cannot have "@" github specifiers.')
   }
 
-  // Detect repo-only references without ":" (e.g., "org/repo" or "org/repo@ref").
-  // Config filepaths always have a file extension, so if there is no ":" and the
-  // target (minus any @ref suffix) has no ".", treat it as a repo-only reference.
+  // Detect legacy repo-only references without ":" (e.g., "org/repo",
+  // "org/.github", or "org/repo@ref"). Config filepaths have extensions;
+  // extensionless targets are repo-only. ".github" is the legacy exception.
   if (!hasRepoSpecifier && scheme !== 'file') {
     const targetWithoutRef = hasRefSpecifier
       ? _target.slice(0, _target.indexOf('@'))
       : _target
-    if (!targetWithoutRef.includes('.')) {
+    const repoName = targetWithoutRef.split('/').at(-1) || ''
+    if (!repoName.includes('.') || repoName === '.github') {
       // Treat as repo-only: rewrite to "repo:@ref" or "repo:" so normal parsing handles it
       if (hasRefSpecifier) {
         _target = `${targetWithoutRef}:${_target.slice(_target.indexOf('@'))}`

--- a/src/tests/drafter/get-config-files.test.ts
+++ b/src/tests/drafter/get-config-files.test.ts
@@ -345,6 +345,45 @@ describe('getConfigFiles', () => {
       })
     })
 
+    it('should default filepath when _extends is .github', async () => {
+      vi.stubEnv('GITHUB_TOKEN', 'test')
+
+      const parentEndpoint = getContentEndpoint(
+        'jenkinsci',
+        'azure-credentials-plugin',
+        '.github/release-drafter.yml',
+        'master',
+      )
+      const extendsEndpoint = getContentEndpoint(
+        'jenkinsci',
+        '.github',
+        '.github/release-drafter.yml',
+      )
+
+      const scope = nock('https://api.github.com')
+        .get(parentEndpoint)
+        .reply(200, `_extends: .github\ntemplate: child-template`, {
+          'content-type': RAW_CONTENT_TYPE,
+        })
+        .get(extendsEndpoint)
+        .reply(200, `template: parent-template`, {
+          'content-type': RAW_CONTENT_TYPE,
+        })
+
+      const files = await getConfigFiles('release-drafter.yml', {
+        repo: { owner: 'jenkinsci', repo: 'azure-credentials-plugin' },
+        ref: 'master',
+      })
+
+      expect(scope.isDone()).toBe(true)
+      expect(files).toHaveLength(2)
+      expect(files[1].fetchedFrom.filepath).toBe('.github/release-drafter.yml')
+      expect(files[1].fetchedFrom.repo).toEqual({
+        owner: 'jenkinsci',
+        repo: '.github',
+      })
+    })
+
     it('should default filepath with custom config name', async () => {
       vi.stubEnv('GITHUB_TOKEN', 'test')
 

--- a/src/tests/drafter/parse-config-target.test.ts
+++ b/src/tests/drafter/parse-config-target.test.ts
@@ -253,6 +253,35 @@ const testSuites: Array<{
     },
   },
   {
+    suiteName: 'repo-only .github special repo',
+    input: [
+      '.github',
+      {
+        repo: { owner: 'jenkinsci', repo: 'azure-credentials-plugin' },
+        ref: 'main',
+      },
+    ],
+    expected: {
+      scheme: 'github',
+      filepath: '',
+      ref: undefined,
+      repo: { owner: 'jenkinsci', repo: '.github' },
+    },
+  },
+  {
+    suiteName: 'repo-only owner/.github special repo',
+    input: [
+      'jenkinsci/.github',
+      { repo: { owner: 'octocat', repo: 'hello-world' }, ref: 'main' },
+    ],
+    expected: {
+      scheme: 'github',
+      filepath: '',
+      ref: undefined,
+      repo: { owner: 'jenkinsci', repo: '.github' },
+    },
+  },
+  {
     suiteName: 'repo-only with colon, ref, and no filepath',
     input: [
       'ansible/team-devtools:@main',


### PR DESCRIPTION
## Summary
- Treat legacy repo-only _extends targets ending in .github as repository references, not file paths
- Keep existing extensionless repo-only behavior unchanged
- Add coverage for _extends: .github resolving to org/.github release-drafter config

## Verification
- npm run test:run -- src/tests/drafter/parse-config-target.test.ts src/tests/drafter/get-config-files.test.ts
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `.github` as a valid repo-only `_extends` reference
> - Updates `parseConfigTarget` in [parse-config-target.ts](https://github.com/release-drafter/release-drafter/pull/1650/files#diff-d4ebbfdc3a87ad1c0f03abfb928d6319a1863fec0d7e9a07755490a13ded0118) to extract the last path segment as the repo name when no `:` is present, checking that segment (rather than the full string) for a `.` to detect repo-only refs.
> - Adds a special case so `.github` is always treated as a repo name, not a file extension, enabling `_extends: .github` and `_extends: owner/.github`.
> - Owners with dots (e.g. `org.name/repo`) no longer cause false positives in repo-only detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6dc51c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->