### PR TITLE
feat: log all config sources

### DIFF
--- a/dist/actions/drafter/run.js
+++ b/dist/actions/drafter/run.js
@@ -490,8 +490,10 @@ var configSchemaDefaults = Object.fromEntries(Object.entries({
 //#region src/actions/drafter/config/get-config.ts
 var getConfig = async (configName) => {
 	const { config, contexts } = await composeConfigGet(configName, context);
-	if (contexts.length > 1) info(`Config was fetched from ${contexts.length} different contexts.`);
-	else if (contexts.length === 1) info(`Config fetched ${contexts[0].scheme === "file" ? "locally" : `on remote "${contexts[0].repo.owner}/${contexts[0].repo.repo}${contexts[0].ref ? `@${contexts[0].ref}` : ""}"${!contexts[0].ref ? " on the default branch" : ""}`}.`);
+	contexts.forEach(({ filepath, ref, repo, scheme }) => {
+		const remotePath = `${repo.owner}/${repo.repo}/${filepath}${ref ? `@${ref}` : ""}`;
+		info(`Config fetched ${scheme === "file" ? `locally from "${filepath}"` : `from "${remotePath}"${ref ? "" : " on the default branch"}`}.`);
+	});
 	return configSchema.parse(config);
 };
 //#endregion

--- a/src/actions/drafter/config/get-config.ts
+++ b/src/actions/drafter/config/get-config.ts
@@ -6,13 +6,15 @@ import { configSchema } from './schemas/config.schema.ts'
 export const getConfig = async (configName: string) => {
   const { config, contexts } = await composeConfigGet(configName, context)
 
-  if (contexts.length > 1) {
-    core.info(`Config was fetched from ${contexts.length} different contexts.`)
-  } else if (contexts.length === 1) {
-    core.info(
-      `Config fetched ${contexts[0].scheme === 'file' ? 'locally' : `on remote "${contexts[0].repo.owner}/${contexts[0].repo.repo}${contexts[0].ref ? `@${contexts[0].ref}` : ''}"${!contexts[0].ref ? ' on the default branch' : ''}`}.`,
-    )
-  }
+  contexts.forEach(({ filepath, ref, repo, scheme }) => {
+    const remotePath = `${repo.owner}/${repo.repo}/${filepath}${ref ? `@${ref}` : ''}`
+    const location =
+      scheme === 'file'
+        ? `locally from "${filepath}"`
+        : `from "${remotePath}"${ref ? '' : ' on the default branch'}`
+
+    core.info(`Config fetched ${location}.`)
+  })
 
   return configSchema.parse(config)
 }

--- a/src/tests/drafter/drafter.e2e.test.ts
+++ b/src/tests/drafter/drafter.e2e.test.ts
@@ -19,6 +19,20 @@ describe('drafter e2e', () => {
       it('creates a release draft targeting that branch', async () => {
         await mockContext('push')
         mocks.config.mockReturnValue('config')
+        mocks.getContextsConfigWasFetchedFrom.mockReturnValue([
+          {
+            filepath: '.github/release-drafter.yml',
+            scheme: 'github',
+            ref: 'master',
+            repo: { owner: 'toolmantim', repo: 'release-drafter' },
+          },
+          {
+            filepath: '.github/release-drafter-base.yml',
+            scheme: 'github',
+            ref: undefined,
+            repo: { owner: 'toolmantim', repo: '.github' },
+          },
+        ])
 
         const gqlScope = mockGraphqlQuery({
           payload: 'graphql-comparison-no-prs',
@@ -44,6 +58,14 @@ describe('drafter e2e', () => {
             },
           ]
         `)
+        expect(
+          mocks.core.info.mock.calls
+            .flat()
+            .filter((message) => message.startsWith('Config fetched')),
+        ).toEqual([
+          'Config fetched from "toolmantim/release-drafter/.github/release-drafter.yml@master".',
+          'Config fetched from "toolmantim/.github/.github/release-drafter-base.yml" on the default branch.',
+        ])
 
         expect(scope.isDone()).toBe(true) // should call the mocked endpoints
         expect(gqlScope.pendingMocks().length).toBe(0) // should call the mocked endpoints

--- a/src/tests/drafter/get-config.test.ts
+++ b/src/tests/drafter/get-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getConfig } from '#src/actions/drafter/config/get-config.ts'
+import { mocks } from '#tests/mocks/index.ts'
+
+describe('get drafter config', () => {
+  it('logs the file path and ref for every fetched remote config', async () => {
+    mocks.config.mockReturnValue('config')
+    mocks.getContextsConfigWasFetchedFrom.mockReturnValue([
+      {
+        filepath: '.github/release-drafter.yml',
+        scheme: 'github',
+        ref: 'main',
+        repo: { owner: 'octocat', repo: 'hello-world' },
+      },
+      {
+        filepath: '.github/base.yml',
+        scheme: 'github',
+        ref: undefined,
+        repo: { owner: 'octocat', repo: '.github' },
+      },
+    ])
+
+    await getConfig('release-drafter.yml')
+
+    expect(mocks.core.info).toHaveBeenCalledWith(
+      'Config fetched from "octocat/hello-world/.github/release-drafter.yml@main".',
+    )
+    expect(mocks.core.info).toHaveBeenCalledWith(
+      'Config fetched from "octocat/.github/.github/base.yml" on the default branch.',
+    )
+  })
+
+  it('logs the file path for a locally fetched config', async () => {
+    mocks.config.mockReturnValue('config')
+    mocks.getContextsConfigWasFetchedFrom.mockReturnValue([
+      {
+        filepath: 'config/release-drafter.yml',
+        scheme: 'file',
+        ref: 'main',
+        repo: { owner: 'octocat', repo: 'hello-world' },
+      },
+    ])
+
+    await getConfig('release-drafter.yml')
+
+    expect(mocks.core.info).toHaveBeenCalledWith(
+      'Config fetched locally from "config/release-drafter.yml".',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- log every configuration source used by the drafter
- include the repository, filepath, and ref or default-branch status
- distinguish local configuration files from remote sources
- add coverage for composed remote configs and local configs

## Why

The existing multi-config message only reported the number of contexts, which made it difficult to diagnose exactly which configuration files contributed to the final config.

## Validation

- `npm run all`
- 442 tests passed

Fixes #1673


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log per-context config source info in `getConfig`
> Updates `getConfig` in [get-config.ts](https://github.com/release-drafter/release-drafter/pull/1674/files#diff-4fa24ac4d389019e74022c3d3653f001c36e364461681f1f3af93e5d662da6fd) to log an `info` line for every fetched context instead of a single conditional summary. Remote contexts log the owner/repo/filepath with an optional ref or a "default branch" note; local contexts log the file path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9f0c47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->