### PR TITLE
fix: preserve proxy-aware fetch in octokit client

### DIFF
--- a/dist/chunks/ignore.js
+++ b/dist/chunks/ignore.js
@@ -32447,17 +32447,10 @@ retry.VERSION = VERSION;
 //#endregion
 //#region src/common/get-octokit.ts
 var getOctokit = () => {
-	return getOctokit$1(process$1.env.GITHUB_TOKEN || "", {
-		log: {
-			...core_exports,
-			warn: warning
-		},
-		request: { 
-		/**
-		* Allows nock to intercept requests in tests
-		*/
-fetch: global.fetch }
-	}, paginateGraphQL, retry);
+	return getOctokit$1(process$1.env.GITHUB_TOKEN || "", { log: {
+		...core_exports,
+		warn: warning
+	} }, paginateGraphQL, retry);
 };
 //#endregion
 //#region src/common/config/get-config-file-from-repo.ts

--- a/src/common/get-octokit.ts
+++ b/src/common/get-octokit.ts
@@ -8,16 +8,17 @@ import {
 import { type RetryPlugin, retry } from '@octokit/plugin-retry'
 
 export const getOctokit = () => {
+  // Deliberately no `request` option: `@octokit/core` shallow-merges it, so
+  // supplying one replaces the proxy-aware `fetch` and agent that
+  // `@actions/github` builds from `http_proxy`/`https_proxy`. That silently
+  // disables proxy support, which GitHub Enterprise Server and corporate-proxy
+  // setups depend on.
+  //
+  // @see src/tests/get-octokit-proxy.test.ts
   return createOctokit(
     process.env.GITHUB_TOKEN || '',
     {
       log: { ...core, warn: core.warning },
-      request: {
-        /**
-         * Allows nock to intercept requests in tests
-         */
-        fetch: global.fetch,
-      },
     },
     paginateGraphQL,
     retry,

--- a/src/common/get-octokit.ts
+++ b/src/common/get-octokit.ts
@@ -8,13 +8,6 @@ import {
 import { type RetryPlugin, retry } from '@octokit/plugin-retry'
 
 export const getOctokit = () => {
-  // Deliberately no `request` option: `@octokit/core` shallow-merges it, so
-  // supplying one replaces the proxy-aware `fetch` and agent that
-  // `@actions/github` builds from `http_proxy`/`https_proxy`. That silently
-  // disables proxy support, which GitHub Enterprise Server and corporate-proxy
-  // setups depend on.
-  //
-  // @see src/tests/get-octokit-proxy.test.ts
   return createOctokit(
     process.env.GITHUB_TOKEN || '',
     {

--- a/src/tests/get-octokit-proxy.test.ts
+++ b/src/tests/get-octokit-proxy.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOctokit } from '#src/common/get-octokit.ts'
+
+// The suite-wide setup swaps in Node's global fetch so nock can intercept.
+// These tests assert the real production wiring, so opt out of that.
+vi.unmock('@actions/github')
+
+/**
+ * `@octokit/core` shallow-merges the `request` option, so passing it at all
+ * replaces the proxy-aware `fetch` and agent that `@actions/github` installs
+ * from `http_proxy`/`https_proxy`. That breaks GitHub Enterprise Server and
+ * corporate-proxy setups, and it fails silently — nothing errors, requests just
+ * bypass the proxy.
+ *
+ * These tests pin the production configuration so a `request: { fetch }`
+ * override cannot be reintroduced unnoticed.
+ */
+const requestDefaults = (octokit: ReturnType<typeof getOctokit>) =>
+  (
+    octokit.request as unknown as {
+      endpoint: {
+        DEFAULTS: { request: { fetch?: unknown; agent?: unknown } }
+      }
+    }
+  ).endpoint.DEFAULTS.request
+
+describe('getOctokit proxy support', () => {
+  beforeEach(() => {
+    vi.stubEnv('GITHUB_TOKEN', 'test')
+  })
+
+  it("keeps @actions/github's proxy-aware fetch rather than replacing it", () => {
+    const { fetch } = requestDefaults(getOctokit())
+
+    expect(fetch).toBeTypeOf('function')
+    // The proxy-aware wrapper, not a bare fetch handed straight through.
+    expect(fetch).not.toBe(globalThis.fetch)
+  })
+
+  it('keeps the proxy agent when a proxy is configured', () => {
+    vi.stubEnv('https_proxy', 'http://proxy.invalid:8080')
+
+    expect(requestDefaults(getOctokit()).agent).toBeDefined()
+  })
+})

--- a/src/tests/get-octokit-proxy.test.ts
+++ b/src/tests/get-octokit-proxy.test.ts
@@ -8,12 +8,8 @@ vi.unmock('@actions/github')
 /**
  * `@octokit/core` shallow-merges the `request` option, so passing it at all
  * replaces the proxy-aware `fetch` and agent that `@actions/github` installs
- * from `http_proxy`/`https_proxy`. That breaks GitHub Enterprise Server and
- * corporate-proxy setups, and it fails silently — nothing errors, requests just
- * bypass the proxy.
- *
- * These tests pin the production configuration so a `request: { fetch }`
- * override cannot be reintroduced unnoticed.
+ * from `http_proxy`/`https_proxy`. That silently breaks GitHub Enterprise
+ * Server and corporate proxies, so pin the production configuration here.
  */
 const requestDefaults = (octokit: ReturnType<typeof getOctokit>) =>
   (

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -21,17 +21,11 @@ vi.mock(
   (await import('#tests/mocks/index.ts')).mockedConfigModule,
 )
 /**
- * `@actions/github` hands octokit a `fetch` backed by the `undici` package.
- * nock cannot intercept that — the requests escape to the real network, and
- * `nock.disableNetConnect()` does not catch them either. Swap in Node's global
- * `fetch`, which nock does understand.
+ * `@actions/github` hands octokit an `undici`-backed `fetch` that nock cannot
+ * intercept. Swap in Node's global `fetch`, which nock understands.
  *
- * Confined to tests on purpose: production must keep `@actions/github`'s own
- * `fetch` so the proxy dispatcher it builds from `http_proxy`/`https_proxy`
- * survives, which is what GitHub Enterprise Server and corporate proxies rely
- * on. `src/tests/get-octokit-proxy.test.ts` unmocks this to assert that.
- *
- * @see src/common/get-octokit.ts
+ * Tests only — production keeps `@actions/github`'s `fetch` so its
+ * `http_proxy`/`https_proxy` dispatcher survives.
  */
 vi.mock(import('@actions/github'), async (iom) => {
   const om = await iom()

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -20,6 +20,35 @@ vi.mock(
   import('#src/common/config/index.ts'),
   (await import('#tests/mocks/index.ts')).mockedConfigModule,
 )
+/**
+ * `@actions/github` hands octokit a `fetch` backed by the `undici` package.
+ * nock cannot intercept that — the requests escape to the real network, and
+ * `nock.disableNetConnect()` does not catch them either. Swap in Node's global
+ * `fetch`, which nock does understand.
+ *
+ * Confined to tests on purpose: production must keep `@actions/github`'s own
+ * `fetch` so the proxy dispatcher it builds from `http_proxy`/`https_proxy`
+ * survives, which is what GitHub Enterprise Server and corporate proxies rely
+ * on. `src/tests/get-octokit-proxy.test.ts` unmocks this to assert that.
+ *
+ * @see src/common/get-octokit.ts
+ */
+vi.mock(import('@actions/github'), async (iom) => {
+  const om = await iom()
+  return {
+    ...om,
+    getOctokit: ((token, options, ...plugins) =>
+      om.getOctokit(
+        token,
+        {
+          ...options,
+          request: { ...options?.request, fetch: globalThis.fetch },
+        },
+        ...plugins,
+      )) as typeof om.getOctokit,
+  }
+})
+
 vi.mock(import('@actions/core'), async (iom) => {
   const om = await iom()
   return {


### PR DESCRIPTION
## Problem

`getOctokit` passed `request: { fetch: global.fetch }` with a comment saying it "allows nock to intercept requests in tests".

`@octokit/core` **shallow-merges** the `request` option, so supplying it at all replaces the proxy-aware `fetch` and agent that `@actions/github` builds from `http_proxy`/`https_proxy`. Proxy support was silently disabled — nothing errors, requests just bypass the proxy. That breaks GitHub Enterprise Server and corporate-proxy setups.

## Fix

- Drop the `request` override from `src/common/get-octokit.ts` so production keeps `@actions/github`'s proxy-aware `fetch`.
- Move the test-only fetch swap into `src/tests/setup.ts`: a mock of `@actions/github` injects `globalThis.fetch`, which nock can intercept (nock cannot intercept the `undici`-backed fetch, and `nock.disableNetConnect()` does not catch it either).
- Add `src/tests/get-octokit-proxy.test.ts`, which `vi.unmock`s `@actions/github` to assert the real production wiring — that the fetch is not a bare `globalThis.fetch`, and that the agent is present when `https_proxy` is set. This pins the behaviour so the override cannot be reintroduced unnoticed.

## Verification

`npm run all` — 440 tests pass across 23 files, lint/tsc/schemas/build clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getOctokit` to preserve proxy-aware fetch from `@actions/github`
> - Removes the explicit `request.fetch = global.fetch` override in [`get-octokit.ts`](https://github.com/release-drafter/release-drafter/pull/1682/files#diff-15d574e2e6cb01e4eb4587a2bbdc686e28ed7d257e098b963de18e4a6b95286f), allowing Octokit to use the default fetch/agent provided by `@actions/github`, which respects `https_proxy`.
> - Adds a test mock in [`setup.ts`](https://github.com/release-drafter/release-drafter/pull/1682/files#diff-4a7b05cd6cc30011e9e0f101e6058851da233e0b3debb84839d39452c8095642) that injects `globalThis.fetch` only in test environments so nock interception continues to work.
> - Adds a new test suite in [`get-octokit-proxy.test.ts`](https://github.com/release-drafter/release-drafter/pull/1682/files#diff-dd3e599d73b55840d2649838157cd7bf438d3592f5198d2d201678ef619d2c24) that verifies `request.fetch` is not `globalThis.fetch` and that `request.agent` is set when `https_proxy` is configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bb49ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->